### PR TITLE
Provide consistent fallback mappings

### DIFF
--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -32,4 +32,10 @@ if $TMUX != ''
   nmap <silent> <c-h> :call <SID>TmuxWinCmd('h')<cr>
   nmap <silent> <c-l> :call <SID>TmuxWinCmd('l')<cr>
   nmap <silent> <c-\> :call <SID>TmuxWinCmd('p')<cr>
+else
+  noremap <C-j> <C-w>j
+  noremap <C-k> <C-w>k
+  noremap <C-h> <C-w>h
+  noremap <C-l> <C-w>l
+  noremap <C-\> <C-w>p
 end


### PR DESCRIPTION
If I fire up vim outside of tmux, I want consistent window-movement mappings.

In general, I don't want plugins automatically mapping things for me, but this is a happy medium for now.

Future refactor: expose functions for MoveUp, MoveRight, MoveDown, MoveLeft, MovePrevious and leave it up to the user to map those functions. The functions themselves would be smart enough to shell out when in tmux, or pass through to the traditional movement otherwise. This leaves the mapping entirely controlled by the user who doesn't have to worry about checking for tmux either.
