### PR TITLE
Optional Maps

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -6,6 +6,34 @@ captures the Vim specific configuration. In order to get the full
 functionality, there is a script file and a set of tmux mappings that are
 needed. Please see the previously mentioned gist for additional instructions.
 
+## Usage
+
+This plugin, when used in conjunction with the other scripts listed in the gist
+referenced above, will allow for seamless navigation between Vim splits and
+tmux panes. By default it provides the following mappings:
+
+- `<ctrl-h>` => Left
+- `<ctrl-j>` => Down
+- `<ctrl-k>` => Up
+- `<ctrl-l>` => Right
+
+If you don't want the plugin to create any mappings, you can use the four
+provided functions to define your own custom maps. Add the following to your
+vimrc to use custom maps:
+
+``` vim
+let g:tmux_navigator_no_mappings = 1
+
+nmap <silent> {Left-mapping} :TmuxNavigateLeft<cr>
+nmap <silent> {Down-Mapping} :TmuxNavigateDown<cr>
+nmap <silent> {Up-Mapping} :TmuxNavigateUp<cr>
+nmap <silent> {Right-Mapping} :TmuxNavigateRight<cr>
+```
+
+*Note* Each instance of `{Left-Mapping}` or `{Down-Mapping}` must be replaced
+in the above code with the desired mapping. Ie, the mapping for `<ctrl-h>` =>
+Left would be created with `nmap <silent> <c-h> :TmuxNavigateLeft<cr>`.
+
 ## Installation
 
 The main goal of this repo is to wrap Mislav's original plugin for easy

--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -2,34 +2,62 @@
 " no more windows in that direction, forwards the operation to tmux.
 " Additionally, <C-\> toggles between last active vim splits/tmux panes.
 
-if $TMUX != ''
-  let s:tmux_is_last_pane = 0
-  au WinEnter * let s:tmux_is_last_pane = 0
+if exists("g:loaded_tmux_navigator") || &cp || v:version < 700
+  finish
+endif
+let g:loaded_tmux_navigator = 1
 
-  " Like `wincmd` but also change tmux panes instead of vim windows when needed.
-  function! s:TmuxWinCmd(direction)
-    let nr = winnr()
-    let tmux_last_pane = (a:direction == 'p' && s:tmux_is_last_pane)
-    if !tmux_last_pane
-      " try to switch windows within vim
-      exec 'wincmd ' . a:direction
-    endif
-    " Forward the switch panes command to tmux if:
-    " a) we're toggling between the last tmux pane;
-    " b) we tried switching windows in vim but it didn't have effect.
-    if tmux_last_pane || nr == winnr()
-      let cmd = 'tmux select-pane -' . tr(a:direction, 'phjkl', 'lLDUR')
-      silent call system(cmd)
-      let s:tmux_is_last_pane = 1
-    else
-      let s:tmux_is_last_pane = 0
-    endif
-  endfunction
+function! s:UseTmuxNavigatorMappings()
+  return !exists("g:tmux_navigator_no_mappings") || !g:tmux_navigator_no_mappings
+endfunction
 
-  " navigate between split windows/tmux panes
-  nmap <silent> <c-j> :call <SID>TmuxWinCmd('j')<cr>
-  nmap <silent> <c-k> :call <SID>TmuxWinCmd('k')<cr>
-  nmap <silent> <c-h> :call <SID>TmuxWinCmd('h')<cr>
-  nmap <silent> <c-l> :call <SID>TmuxWinCmd('l')<cr>
-  nmap <silent> <c-\> :call <SID>TmuxWinCmd('p')<cr>
-end
+function! s:InTmuxSession()
+  return $TMUX != ''
+endfunction
+
+let s:tmux_is_last_pane = 0
+au WinEnter * let s:tmux_is_last_pane = 0
+
+" Like `wincmd` but also change tmux panes instead of vim windows when needed.
+function! s:TmuxWinCmd(direction)
+  if s:InTmuxSession()
+    call s:TmuxAwareNavigate(a:direction)
+  else
+    call s:VimNavigate(a:direction)
+  endif
+endfunction
+
+function! s:TmuxAwareNavigate(direction)
+  let nr = winnr()
+  let tmux_last_pane = (a:direction == 'p' && s:tmux_is_last_pane)
+  if !tmux_last_pane
+    " try to switch windows within vim
+    exec 'wincmd ' . a:direction
+  endif
+  " Forward the switch panes command to tmux if:
+  " a) we're toggling between the last tmux pane;
+  " b) we tried switching windows in vim but it didn't have effect.
+  if tmux_last_pane || nr == winnr()
+    let cmd = 'tmux select-pane -' . tr(a:direction, 'phjkl', 'lLDUR')
+    silent call system(cmd)
+    let s:tmux_is_last_pane = 1
+  else
+    let s:tmux_is_last_pane = 0
+  endif
+endfunction
+
+function! s:VimNavigate(direction)
+  execute 'wincmd ' . a:direction
+endfunction
+
+command! TmuxNavigateLeft call <SID>TmuxWinCmd('h')
+command! TmuxNavigateDown call <SID>TmuxWinCmd('j')
+command! TmuxNavigateUp call <SID>TmuxWinCmd('k')
+command! TmuxNavigateRight call <SID>TmuxWinCmd('l')
+
+if s:UseTmuxNavigatorMappings()
+  nmap <silent> <c-h> :TmuxNavigateLeft<cr>
+  nmap <silent> <c-j> :TmuxNavigateDown<cr>
+  nmap <silent> <c-k> :TmuxNavigateUp<cr>
+  nmap <silent> <c-l> :TmuxNavigateRight<cr>
+endif


### PR DESCRIPTION
Based on [this pull](https://github.com/christoomey/vim-tmux-navigator/pull/1), these commits make two changes:
- Expose commands for the motions
- Provide an option for opting out of the default maps (handle both while in Tmux, and not)
