### PR TITLE
Use nnoremap instead of nmap.

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -22,16 +22,16 @@ vimrc to use custom maps:
 ``` vim
 let g:tmux_navigator_no_mappings = 1
 
-nmap <silent> {Left-mapping} :TmuxNavigateLeft<cr>
-nmap <silent> {Down-Mapping} :TmuxNavigateDown<cr>
-nmap <silent> {Up-Mapping} :TmuxNavigateUp<cr>
-nmap <silent> {Right-Mapping} :TmuxNavigateRight<cr>
-nmap <silent> {Previoust-Mapping} :TmuxNavigatePrevious<cr>
+nnoremap <silent> {Left-mapping} :TmuxNavigateLeft<cr>
+nnoremap <silent> {Down-Mapping} :TmuxNavigateDown<cr>
+nnoremap <silent> {Up-Mapping} :TmuxNavigateUp<cr>
+nnoremap <silent> {Right-Mapping} :TmuxNavigateRight<cr>
+nnoremap <silent> {Previoust-Mapping} :TmuxNavigatePrevious<cr>
 ```
 
 *Note* Each instance of `{Left-Mapping}` or `{Down-Mapping}` must be replaced
 in the above code with the desired mapping. Ie, the mapping for `<ctrl-h>` =>
-Left would be created with `nmap <silent> <c-h> :TmuxNavigateLeft<cr>`.
+Left would be created with `nnoremap <silent> <c-h> :TmuxNavigateLeft<cr>`.
 
 ## Installation
 

--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -57,9 +57,9 @@ command! TmuxNavigateRight call <SID>TmuxWinCmd('l')
 command! TmuxNavigatePrevious call <SID>TmuxWinCmd('p')
 
 if s:UseTmuxNavigatorMappings()
-  nmap <silent> <c-h> :TmuxNavigateLeft<cr>
-  nmap <silent> <c-j> :TmuxNavigateDown<cr>
-  nmap <silent> <c-k> :TmuxNavigateUp<cr>
-  nmap <silent> <c-l> :TmuxNavigateRight<cr>
-  nmap <silent> <c-\> :TmuxNavigatePrevious<cr>
+  nnoremap <silent> <c-h> :TmuxNavigateLeft<cr>
+  nnoremap <silent> <c-j> :TmuxNavigateDown<cr>
+  nnoremap <silent> <c-k> :TmuxNavigateUp<cr>
+  nnoremap <silent> <c-l> :TmuxNavigateRight<cr>
+  nnoremap <silent> <c-\> :TmuxNavigatePrevious<cr>
 endif


### PR DESCRIPTION
`nmap` is generally not what you want to use in Vim library mappings. I've remapped `:` in my personal vimrc, so vim-tmux-navigator breaks. This commit makes the map non-recursive.
