### PR TITLE
Fix vitality.vim screen junk

### DIFF
--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -44,6 +44,7 @@ function! s:TmuxAwareNavigate(direction)
   if tmux_last_pane || nr == winnr()
     let cmd = 'tmux select-pane -' . tr(a:direction, 'phjkl', 'lLDUR')
     silent call system(cmd)
+    redraw!
     let s:tmux_is_last_pane = 1
   else
     let s:tmux_is_last_pane = 0


### PR DESCRIPTION
This fixes #7 where a rouge `^[[O` could end up on the screen.

https://github.com/sjl/vitality.vim/issues/19
