### PR TITLE
Check global vitality variable

### DIFF
--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -44,7 +44,7 @@ function! s:TmuxAwareNavigate(direction)
   if tmux_last_pane || nr == winnr()
     let cmd = 'tmux select-pane -' . tr(a:direction, 'phjkl', 'lLDUR')
     silent call system(cmd)
-    if exists('loaded_vitality')
+    if exists('g:loaded_vitality')
       redraw!
     endif
     let s:tmux_is_last_pane = 1


### PR DESCRIPTION
For some reason checking just `loaded_vitality` in the script doesn't work. I've also looked at the vitality code and don't see why. To prove this you can add `echom exists('loaded_vitality')` anywhere and see that it doesn't return true while `echom exists('g:loaded_vitality')` does.
