### PR TITLE
Suggest tmux if-shell instead of run-shell

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -48,11 +48,11 @@ this customization.
 
 ``` tmux
 # Smart pane switching with awareness of vim splits
-bind -n C-h run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)vim(diff)?$' && tmux send-keys C-h) || tmux select-pane -L"
-bind -n C-j run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)vim(diff)?$' && tmux send-keys C-j) || tmux select-pane -D"
-bind -n C-k run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)vim(diff)?$' && tmux send-keys C-k) || tmux select-pane -U"
-bind -n C-l run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)vim(diff)?$' && tmux send-keys C-l) || tmux select-pane -R"
-bind -n C-\ run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)vim(diff)?$' && tmux send-keys 'C-\\') || tmux select-pane -l"
+bind -n C-h if "echo '#{pane_current_command}' | grep -iqE '(^|\/)vim(diff)?$'" 'send-keys C-h' 'select-pane -L'
+bind -n C-j if "echo '#{pane_current_command}' | grep -iqE '(^|\/)vim(diff)?$'" 'send-keys C-j' 'select-pane -D'
+bind -n C-k if "echo '#{pane_current_command}' | grep -iqE '(^|\/)vim(diff)?$'" 'send-keys C-k' 'select-pane -U'
+bind -n C-l if "echo '#{pane_current_command}' | grep -iqE '(^|\/)vim(diff)?$'" 'send-keys C-l' 'select-pane -R'
+bind -n C-\ if "echo '#{pane_current_command}' | grep -iqE '(^|\/)vim(diff)?$'" 'send-keys C-\' 'select-pane -l'
 ```
 
 Thanks to Christopher Sexton who provided the updated tmux configuration in


### PR DESCRIPTION
Modify README to suggest use of if-shell (shortcut `if`) rather than
run-shell (shortcut `run`), this makes the configuration a bit
easier to read since it doesn't require as many levels of quoting and
has direct support for an "else" branch rather than requiring chained
boolean operators.

Also change from using `tmux display-message -p` to `echo` when
retrieving the current command.  The expansion is done by `run` or `if`
anyway, and echo should be lighter weight than running another tmux
process and is definitely shorter.
