### PR TITLE
Optionally autosave when switching out of vim

### DIFF
--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -42,6 +42,9 @@ function! s:TmuxAwareNavigate(direction)
   " a) we're toggling between the last tmux pane;
   " b) we tried switching windows in vim but it didn't have effect.
   if tmux_last_pane || nr == winnr()
+    if exists('g:tmux_navigator_save_on_switch')
+        update
+    endif
     let cmd = 'tmux select-pane -' . tr(a:direction, 'phjkl', 'lLDUR')
     silent call system(cmd)
     if exists('g:loaded_vitality')


### PR DESCRIPTION
Optionally (if g:tmux_navigator_save_on_switch defined) save the current file when switching out of vim.

I really like the option to autosave(like on the the gVim's 'focus lost' event).
