### PR TITLE
Fix tmux.conf brakes for vi, gvim, view, gview.

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -48,11 +48,11 @@ this customization.
 
 ``` tmux
 # Smart pane switching with awareness of vim splits
-bind -n C-h run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)vim(diff)?$' && tmux send-keys C-h) || tmux select-pane -L"
-bind -n C-j run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)vim(diff)?$' && tmux send-keys C-j) || tmux select-pane -D"
-bind -n C-k run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)vim(diff)?$' && tmux send-keys C-k) || tmux select-pane -U"
-bind -n C-l run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)vim(diff)?$' && tmux send-keys C-l) || tmux select-pane -R"
-bind -n C-\ run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)vim(diff)?$' && tmux send-keys 'C-\\') || tmux select-pane -l"
+bind -n C-h run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)g?(view|vim?)(diff)?$' && tmux send-keys C-h) || tmux select-pane -L"
+bind -n C-j run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)g?(view|vim?)(diff)?$' && tmux send-keys C-j) || tmux select-pane -D"
+bind -n C-k run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)g?(view|vim?)(diff)?$' && tmux send-keys C-k) || tmux select-pane -U"
+bind -n C-l run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)g?(view|vim?)(diff)?$' && tmux send-keys C-l) || tmux select-pane -R"
+bind -n C-\ run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)g?(view|vim?)(diff)?$' && tmux send-keys 'C-\\') || tmux select-pane -l"
 ```
 
 Thanks to Christopher Sexton who provided the updated tmux configuration in

--- a/pattern-check
+++ b/pattern-check
@@ -6,8 +6,8 @@
 
 set -e
 
-vim_pattern='(^|/)vim(diff)?$'
-match_tests=(vim Vim VIM vimdiff /usr/local/bin/vim)
+vim_pattern='(^|\/)g?(view|vim?)(diff)?$'
+match_tests=(vim Vim VIM vimdiff /usr/local/bin/vim vi gvim view gview)
 no_match_tests=( /Users/christoomey/.vim/thing /usr/local/bin/start-vim )
 
 echo "Testing against pattern: $vim_pattern"


### PR DESCRIPTION
This pull request edits the .tmux.conf provided in the README to grep
'-iqE '(^|\/)g?(view|vim?)(diff)?$'.

This change makes it so that the same configuration will work for either
vi vim gvim view or gview setups
