### PR TITLE
Extend C-[h,j,k,l] mappings to accept a count prefix

### DIFF
--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -24,12 +24,21 @@ let s:tmux_is_last_pane = 0
 au WinEnter * let s:tmux_is_last_pane = 0
 
 " Like `wincmd` but also change tmux panes instead of vim windows when needed.
-function! s:TmuxWinCmd(direction)
-  if s:InTmuxSession()
-    call s:TmuxAwareNavigate(a:direction)
-  else
-    call s:VimNavigate(a:direction)
+function! s:TmuxWinCmd(direction, ...)
+  let rep = 0
+  let reps = 1
+  if a:0 > 0 && a:1 >0
+    let reps = a:1
   endif
+
+  while rep < reps
+    if s:InTmuxSession()
+      call s:TmuxAwareNavigate(a:direction)
+    else
+      call s:VimNavigate(a:direction)
+    endif
+    let rep += 1
+  endwhile
 endfunction
 
 function! s:TmuxAwareNavigate(direction)
@@ -61,16 +70,16 @@ function! s:VimNavigate(direction)
   endtry
 endfunction
 
-command! TmuxNavigateLeft call <SID>TmuxWinCmd('h')
-command! TmuxNavigateDown call <SID>TmuxWinCmd('j')
-command! TmuxNavigateUp call <SID>TmuxWinCmd('k')
-command! TmuxNavigateRight call <SID>TmuxWinCmd('l')
+command! -nargs=1 TmuxNavigateLeft call <SID>TmuxWinCmd('h', <args>)
+command! -nargs=1 TmuxNavigateDown call <SID>TmuxWinCmd('j', <args>)
+command! -nargs=1 TmuxNavigateUp call <SID>TmuxWinCmd('k', <args>)
+command! -nargs=1 TmuxNavigateRight call <SID>TmuxWinCmd('l', <args>)
 command! TmuxNavigatePrevious call <SID>TmuxWinCmd('p')
 
 if s:UseTmuxNavigatorMappings()
-  nnoremap <silent> <c-h> :TmuxNavigateLeft<cr>
-  nnoremap <silent> <c-j> :TmuxNavigateDown<cr>
-  nnoremap <silent> <c-k> :TmuxNavigateUp<cr>
-  nnoremap <silent> <c-l> :TmuxNavigateRight<cr>
+  nnoremap <silent> <c-h> :<c-u>TmuxNavigateLeft(v:count)<cr>
+  nnoremap <silent> <c-j> :<c-u>TmuxNavigateDown(v:count)<cr>
+  nnoremap <silent> <c-k> :<c-u>TmuxNavigateUp(v:count)<cr>
+  nnoremap <silent> <c-l> :<c-u>TmuxNavigateRight(v:count)<cr>
   nnoremap <silent> <c-\> :TmuxNavigatePrevious<cr>
 endif


### PR DESCRIPTION
This branch extends the count prefix functionality found in <C-w>[h,j,k,l] to <C-[h,j,k,l]>.

For example, in vim while in normal mode, a user could type 2<C-w>h to jump two splits to the left. With this branch, a user can type 2<C-h> and achieve the same effect.

Let me know how you feel about this change. I think it's an improvement in terms of consistency and native feel in vim, but on the other hand, it does create an inequality between vim and tmux. That is, if you try 2<C-h> while in a tmux pane not running vim, you're just going to type '2' in the command line then move one pane to the right. Overall though, I think the improvement in vim is worth it, but please let me know if you have any feedback, whether functional or stylistic.
