### PR TITLE
Not trying to save non-files to disk

### DIFF
--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -60,7 +60,8 @@ function! s:TmuxAwareNavigate(direction)
   " a) we're toggling between the last tmux pane;
   " b) we tried switching windows in vim but it didn't have effect.
   if tmux_last_pane || nr == winnr()
-    if g:tmux_navigator_save_on_switch
+    " Unly save the file if it has a filename
+    if g:tmux_navigator_save_on_switch && @% != ""
       update
     endif
     let args = 'select-pane -' . tr(a:direction, 'phjkl', 'lLDUR')


### PR DESCRIPTION
If the current buffer isn't backed by persistence (i.e. it doesn't have
a filename) then don't run the `update` function.