### PR TITLE
Recognize binary name 'vimx'

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ this customization.
 ``` tmux
 # Smart pane switching with awareness of vim splits
 # See: https://github.com/christoomey/vim-tmux-navigator
-is_vim='echo "#{pane_current_command}" | grep -iqE "(^|\/)g?(view|n?vim?)(diff)?$"'
+is_vim='echo "#{pane_current_command}" | grep -iqE "(^|\/)g?(view|n?vim?x?)(diff)?$"'
 bind -n C-h if-shell "$is_vim" "send-keys C-h" "select-pane -L"
 bind -n C-j if-shell "$is_vim" "send-keys C-j" "select-pane -D"
 bind -n C-k if-shell "$is_vim" "send-keys C-k" "select-pane -U"

--- a/pattern-check
+++ b/pattern-check
@@ -11,8 +11,8 @@ GREEN=$(tput setaf 2)
 YELLOW=$(tput setaf 3)
 NORMAL=$(tput sgr0)
 
-vim_pattern='(^|\/)g?(view|n?vim?)(diff)?$'
-match_tests=(vim Vim VIM vimdiff /usr/local/bin/vim vi gvim view gview nvim)
+vim_pattern='(^|\/)g?(view|n?vim?x?)(diff)?$'
+match_tests=(vim Vim VIM vimdiff /usr/local/bin/vim vi gvim view gview nvim vimx)
 no_match_tests=( /Users/christoomey/.vim/thing /usr/local/bin/start-vim )
 
 display_matches() {


### PR DESCRIPTION
Some distributions ship 'vim' without xterm_clipboard support. A separate
package vim-x11 or similar then ships another binary 'vimx' with that
support.

To support vim-tmux-navigator with such a binary name, adapt the pattern
check to allow an optional 'x'.