### PR TITLE
use * wildcard instead of regex matching to be more portable

### DIFF
--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -12,7 +12,7 @@ if !exists("g:tmux_navigator_save_on_switch")
 endif
 
 function! s:TmuxOrTmateExecutable()
-  if s:StrippedSystemCall("[[ $TMUX =~ tmate ]] && echo 'tmate'") == 'tmate'
+  if s:StrippedSystemCall("[[ $TMUX == *'tmate'* ]] && echo 'tmate'") == 'tmate'
     return "tmate"
   else
     return "tmux"


### PR DESCRIPTION
Hi,

this makes vim-tmux-navigator work with OpenBSD's ksh(1) which
doesn't support regex matching.

I've found this solution on stackoverflow.
Please see http://stackoverflow.com/questions/229551/string-contains-in-bash/229585#229606

Thanks for this plugin!

Cheers,
Fabian