### PR TITLE
Look for vim with ps/awk

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,15 @@ Add the following to your `tmux.conf` file to configure the tmux side of
 this customization.
 
 ``` tmux
-# Smart pane switching with awareness of vim splits
+# Smart pane switching with awareness of Vim splits.
 # See: https://github.com/christoomey/vim-tmux-navigator
-is_vim='echo "#{pane_current_command}" | grep -iqE "(^|\/)g?(view|n?vim?x?)(diff)?$"'
-bind -n C-h if-shell "$is_vim" "send-keys C-h" "select-pane -L"
-bind -n C-j if-shell "$is_vim" "send-keys C-j" "select-pane -D"
-bind -n C-k if-shell "$is_vim" "send-keys C-k" "select-pane -U"
-bind -n C-l if-shell "$is_vim" "send-keys C-l" "select-pane -R"
-bind -n C-\ if-shell "$is_vim" "send-keys C-\\" "select-pane -l"
+is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
+    | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$'"
+bind-key -n C-h if-shell "$is_vim" "send-keys C-h"  "select-pane -L"
+bind-key -n C-j if-shell "$is_vim" "send-keys C-j"  "select-pane -D"
+bind-key -n C-k if-shell "$is_vim" "send-keys C-k"  "select-pane -U"
+bind-key -n C-l if-shell "$is_vim" "send-keys C-l"  "select-pane -R"
+bind-key -n C-\ if-shell "$is_vim" "send-keys C-\\" "select-pane -l"
 ```
 
 Thanks to Christopher Sexton who provided the updated tmux configuration in


### PR DESCRIPTION
This looks for PIDs using ps/awk, ignores a stopped Vim and its childs.

Based on the idea in #96.

TODO
 - [x] try to get rid of awk for performance reasons (`sed`/`cut` would be faster probably), or use a single `awk` invocation/script, which seems to be possible here (maybe also with `sed` even?!).

Leaving this here for reference, in case it might become necessary later:

    # Get last pid in list, without childs of Vim or stopped processes.
    # "T zsh" would be in there after (Neo)vim after "Ctrl-Z" and "fg".
    last_wo_vim_childs="$(echo "$session_childs" \
      | awk "\$2 != $vim_pid && \$1 != $$ && \$2 != $$ && \$3 !~ /T/ {print \$1}" \
      | tail -n1)"

    # We've filtered Vim's process group, so should end up at the pane_pid.
    test "$last_wo_vim_childs" -eq "$1" 2>/dev/null
