### PR TITLE
Revert "Add support for Neovim: tnoremap mappings (#111)"

### DIFF
--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -107,13 +107,4 @@ if s:UseTmuxNavigatorMappings()
   nnoremap <silent> <c-k> :TmuxNavigateUp<cr>
   nnoremap <silent> <c-l> :TmuxNavigateRight<cr>
   nnoremap <silent> <c-\> :TmuxNavigatePrevious<cr>
-
-  if exists(':tnoremap')  " Neovim
-    tnoremap <silent> <c-h> <c-\><c-n>:TmuxNavigateLeft<cr>
-    tnoremap <silent> <c-j> <c-\><c-n>:TmuxNavigateDown<cr>
-    tnoremap <silent> <c-k> <c-\><c-n>:TmuxNavigateUp<cr>
-    tnoremap <silent> <c-l> <c-\><c-n>:TmuxNavigateRight<cr>
-    " Cannot use <c-\> here.
-    " tnoremap <silent> <c-\> <c-\><c-n>:TmuxNavigatePrevious<cr>
-  endif
 endif


### PR DESCRIPTION
This reverts commit e13914d89e9413cfa449f0c3daff18691356f2d1.

Fixes https://github.com/christoomey/vim-tmux-navigator/issues/128.