### PR TITLE
Improve moving out of zoomed tmux pane

### DIFF
--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -10,6 +10,9 @@ let g:loaded_tmux_navigator = 1
 if !exists("g:tmux_navigator_save_on_switch")
   let g:tmux_navigator_save_on_switch = 0
 endif
+if !exists('g:tmux_navigator_zoomed_tmux_delay')
+  let g:tmux_navigator_zoomed_tmux_delay = 0.5
+endif
 
 function! s:TmuxOrTmateExecutable()
   return (match($TMUX, 'tmate') != -1 ? 'tmate' : 'tmux')
@@ -83,7 +86,7 @@ function! s:TmuxAwareNavigate(direction)
     " Handle delay for moving out of zoomed tmux pane.
     " This wraps the tmux args conditionally.
     " 0 to zoom out always. -1 can be used to never zoom out.
-    let timeout = get(g:, 'tmux_navigator_zoomed_tmux_delay', 0.5)
+    let timeout = g:tmux_navigator_zoomed_tmux_delay
     if timeout != 0
       let msg = 'Tmux is zoomed, not moving out.'
       if timeout > 0


### PR DESCRIPTION
There were issues (e.g. #56) and pull requests (#65 and #104) to improve this
behavior, but they were mainly rejected because it breaks other use cases.

This PR adds an option that can be enabled to have the current behavior
(`let g:tmux_navigator_zoomed_tmux_delay = 0`), but it also
recognizes when the user tries to get out of the zoomed pane twice, and
then allows for it, using a configurable delay (`let g:tmux_navigator_zoomed_tmux_delay = 0.5` - the default).
`g:tmux_navigator_zoomed_tmux_delay = -1` can be used to display a tmux message, but not zoom out.

TODO:
- [ ] doc
