### PR TITLE
Improve performance with tmate detection

### DIFF
--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -11,19 +11,6 @@ if !exists("g:tmux_navigator_save_on_switch")
   let g:tmux_navigator_save_on_switch = 0
 endif
 
-function! s:TmuxOrTmateExecutable()
-  if s:StrippedSystemCall("[[ $TMUX == *'tmate'* ]] && echo 'tmate'") == 'tmate'
-    return "tmate"
-  else
-    return "tmux"
-  endif
-endfunction
-
-function! s:StrippedSystemCall(system_cmd)
-  let raw_result = system(a:system_cmd)
-  return substitute(raw_result, '^\s*\(.\{-}\)\s*\n\?$', '\1', '')
-endfunction
-
 function! s:UseTmuxNavigatorMappings()
   return !get(g:, 'tmux_navigator_no_mappings', 0)
 endfunction
@@ -38,7 +25,8 @@ function! s:TmuxSocket()
 endfunction
 
 function! s:TmuxCommand(args)
-  let cmd = s:TmuxOrTmateExecutable() . ' -S ' . s:TmuxSocket() . ' ' . a:args
+  let cmd = (match($TMUX, 'tmate') != -1 ? 'tmate' : 'tmux')
+        \ . ' -S ' . s:TmuxSocket() . ' ' . a:args
   return system(cmd)
 endfunction
 


### PR DESCRIPTION
Remove `s:TmuxOrTmateExecutable`: it is rather expensive to call a
system command and not necessary in this case, because Vim can read and
match on the environment variable directly.

To further optimize this, the `match()` could only be done once, but
this is a huge improvement already.