### PR TITLE
Document clear screen without prefix key in single-pane tmux windows, and add example configs to vim-tmux-navigator.tmux

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,16 @@ bind C-l send-keys 'C-l'
 
 With this enabled you can use `<prefix> C-l` to clear the screen.
 
+The default `<Ctrl-l>` tmux binding can be further configured to send the clear
+screen command without pressing the tmux prefix key if the current window only
+has a single pane. To enable this behavior, replace the `bind-key -n C-l` line
+in your `~/.tmux.conf` with the following:
+
+``` tmux
+bind-key -n C-l if-shell "$is_vim" "send-keys C-l" \
+    "if-shell \"[ '#{window_panes}' -gt 1 ]\" 'select-pane -R' 'send-keys C-l'"
+```
+
 Thanks to [Brian Hogan][] for the tip on how to re-map the clear screen binding.
 
 #### Nesting

--- a/vim-tmux-navigator.tmux
+++ b/vim-tmux-navigator.tmux
@@ -10,3 +10,9 @@ tmux bind-key -n C-\\ if-shell "$is_vim" "send-keys C-\\" "select-pane -l"
 
 # To enable clear screen using <Prefix><Ctrl+l>, uncomment the following line:
 # bind C-l send-keys 'C-l'
+
+# To send the clear screen command without requiring <Prefix> in tmux windows
+# with only a single pane, replace the "tmux bind-key -n C-l" above with the
+# following command:
+# tmux bind-key -n C-l if-shell "$is_vim" "send-keys C-l" \
+#     "if-shell \"[ '#{window_panes}' -gt 1 ]\" 'select-pane -R' 'send-keys C-l'"

--- a/vim-tmux-navigator.tmux
+++ b/vim-tmux-navigator.tmux
@@ -7,3 +7,6 @@ tmux bind-key -n C-j if-shell "$is_vim" "send-keys C-j"  "select-pane -D"
 tmux bind-key -n C-k if-shell "$is_vim" "send-keys C-k"  "select-pane -U"
 tmux bind-key -n C-l if-shell "$is_vim" "send-keys C-l"  "select-pane -R"
 tmux bind-key -n C-\\ if-shell "$is_vim" "send-keys C-\\" "select-pane -l"
+
+# To enable clear screen using <Prefix><Ctrl+l>, uncomment the following line:
+# bind C-l send-keys 'C-l'


### PR DESCRIPTION
For convenience, tmux can be configured to send the clear screen command using `<Ctrl-l>` without requiring the tmux prefix key in tmux windows with only a single pane (i.e., full-terminal tmux windows). This updates `README.md` and the tmux plugin configuration with the necessary binding. The `<Prefix><Ctrl-l>` binding is still required to send the clear screen command in tmux windows with multiple panes.