### PR TITLE
Implement universal OS window navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,49 @@ run '~/.tmux/plugins/tpm/tpm'
 Thanks to Christopher Sexton who provided the updated tmux configuration in
 [this blog post][].
 
+#### OS Window Navigator
+
+In case you wish to enable navigation across windows in your operating system,
+there is initial support for Mac OS X with the aid of
+[Hammerspoon](http://hammerspoon.org/). In order to do so, put the following
+code snippet in your `~/.hammerspoon/init.lua`:
+
+``` lua
+require("hs.ipc")
+
+if not hs.ipc.cliStatus(null, true) then
+  hs.ipc.cliInstall()
+end
+
+function nonRecursiveBind(mods, key, callback)
+  local hotkey
+  hotkey = hs.hotkey.bind(mods, key, function()
+    callback(hotkey, mods, key)
+  end)
+end
+
+function except(programName, callback)
+  return function(hotkey, mods, key)
+    local currentName = hs.window.focusedWindow():application():name()
+    if currentName == programName then
+      hotkey:disable()
+      hs.eventtap.keyStroke(mods, key)
+      hotkey:enable()
+    else
+      callback()
+    end
+  end
+end
+
+nonRecursiveBind({"ctrl"}, "H", except("iTerm2", function() hs.window.focusedWindow():focusWindowWest()  end))
+nonRecursiveBind({"ctrl"}, "J", except("iTerm2", function() hs.window.focusedWindow():focusWindowSouth() end))
+nonRecursiveBind({"ctrl"}, "K", except("iTerm2", function() hs.window.focusedWindow():focusWindowNorth() end))
+nonRecursiveBind({"ctrl"}, "L", except("iTerm2", function() hs.window.focusedWindow():focusWindowEast()  end))
+```
+
+Now, reload your config file and, if you installed `vim-tmux-navigator` with `tpm`, you should be all set to
+navigate windows in your operating system using universal keybindings.
+
 Configuration
 -------------
 

--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -7,6 +7,8 @@ if exists("g:loaded_tmux_navigator") || &cp || v:version < 700
 endif
 let g:loaded_tmux_navigator = 1
 
+let s:os_tmux_navigator = expand('<sfile>:h:h') . "/scripts/os_tmux_navigator.sh"
+
 if !exists("g:tmux_navigator_save_on_switch")
   let g:tmux_navigator_save_on_switch = 0
 endif
@@ -70,7 +72,20 @@ function! s:TmuxAwareNavigate(direction)
     if g:tmux_navigator_save_on_switch
       update
     endif
-    let args = 'select-pane -' . tr(a:direction, 'phjkl', 'lLDUR')
+
+    if a:direction == "h"
+      let g:param = "left"
+    elseif a:direction == "j"
+      let g:param = "down"
+    elseif a:direction == "k"
+      let g:param = "up"
+    elseif a:direction == "l"
+      let g:param = "right"
+    endif
+
+    let args = "run '\"" . s:os_tmux_navigator . "\" " . g:param . "'"
+    echo args
+
     silent call s:TmuxCommand(args)
     if s:NeedsVitalityRedraw()
       redraw!

--- a/scripts/hammerspoon_switcher.sh
+++ b/scripts/hammerspoon_switcher.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+if [ "$1" == 'up' ]; then
+  /usr/local/bin/hs -r -c 'hs.window.focusedWindow():focusWindowNorth()'
+elif [ "$1" == 'down' ]; then
+  /usr/local/bin/hs -r -c 'hs.window.focusedWindow():focusWindowSouth()'
+elif [ "$1" == 'left' ]; then
+  /usr/local/bin/hs -r -c 'hs.window.focusedWindow():focusWindowWest()'
+elif [ "$1" == 'right' ]; then
+  /usr/local/bin/hs -r -c 'hs.window.focusedWindow():focusWindowEast()'
+fi

--- a/scripts/os_tmux_navigator.sh
+++ b/scripts/os_tmux_navigator.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+
+# Based on the blogpost by Daniel Campoverde
+# http://silly-bytes.blogspot.com.br/2016/06/seamlessly-vim-tmux-windowmanager_24.html
+
+CURRENT_DIR=$(dirname "$0")
+SWITCHER="${OS_WINDOW_SWITCHER:-$CURRENT_DIR/hammerspoon_switcher.sh}"
+
+silent() {
+  $* > /dev/null
+}
+
+window_bottom=$(tmux list-panes -F "#{window_height}" | head -n1)
+window_right=$(tmux list-panes -F "#{window_width}" | head -n1)
+window_bottom=$(($window_bottom - 1))
+window_right=$(($window_right - 1))
+pane=$(tmux list-panes -F "#{pane_left} #{pane_right} #{pane_top} #{pane_bottom} #{pane_active}" | grep '.* 1$')
+pane_left=$(echo "$pane" | cut -d' ' -f 1)
+pane_right=$(echo "$pane" | cut -d' ' -f 2)
+pane_top=$(echo "$pane" | cut -d' ' -f 3)
+pane_bottom=$(echo "$pane" | cut -d' ' -f 4)
+
+function os_tmux_up
+{
+  if [[ $pane_top  -eq 0 ]];
+  then
+    silent $SWITCHER up
+  else
+    tmux select-pane -U
+  fi
+}
+
+function os_tmux_down
+{
+  if [[ $pane_bottom  -eq $window_bottom ]];
+  then
+    silent $SWITCHER down
+  else
+    tmux select-pane -D
+  fi
+}
+
+function os_tmux_right
+{
+  if [[ $pane_right  -eq $window_right ]];
+  then
+    silent $SWITCHER right
+  else
+    tmux select-pane -R
+  fi
+}
+
+function os_tmux_left
+{
+  if [[ $pane_left  -eq 0 ]];
+  then
+    silent $SWITCHER left
+  else
+    tmux select-pane -L
+  fi
+}
+
+if [ "$1" == 'up' ]; then
+  os_tmux_up
+elif [ "$1" == 'down' ]; then
+  os_tmux_down
+elif [ "$1" == 'left' ]; then
+  os_tmux_left
+elif [ "$1" == 'right' ]; then
+  os_tmux_right
+fi

--- a/vim-tmux-navigator.tmux
+++ b/vim-tmux-navigator.tmux
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
     | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$'"
-tmux bind-key -n C-h if-shell "$is_vim" "send-keys C-h"  "select-pane -L"
-tmux bind-key -n C-j if-shell "$is_vim" "send-keys C-j"  "select-pane -D"
-tmux bind-key -n C-k if-shell "$is_vim" "send-keys C-k"  "select-pane -U"
-tmux bind-key -n C-l if-shell "$is_vim" "send-keys C-l"  "select-pane -R"
+echo $CURRENT_DIR
+tmux bind-key -n C-h if-shell "$is_vim" "send-keys C-h"  "run-shell \"\"$CURRENT_DIR/scripts/os_tmux_navigator.sh\" left\""
+tmux bind-key -n C-j if-shell "$is_vim" "send-keys C-j"  "run-shell \"\"$CURRENT_DIR/scripts/os_tmux_navigator.sh\" down\""
+tmux bind-key -n C-k if-shell "$is_vim" "send-keys C-k"  "run-shell \"\"$CURRENT_DIR/scripts/os_tmux_navigator.sh\" up\""
+tmux bind-key -n C-l if-shell "$is_vim" "send-keys C-l"  "run-shell \"\"$CURRENT_DIR/scripts/os_tmux_navigator.sh\" right\""
 tmux bind-key -n C-\\ if-shell "$is_vim" "send-keys C-\\" "select-pane -l"


### PR DESCRIPTION
Hey, @christoomey, maybe this pull request might be of interest to the project.

I've always wanted to have `Ctrl + HJKL` to work universally across all windows in
the operating system. So, based on this [blogpost](http://silly-bytes.blogspot.com.br/2016/06/seamlessly-vim-tmux-windowmanager_24.html),
I was able to create a feature branch that implements just that.

As a matter of fact, it already solves my problem. But, since it may of of interest to other users
of this plugin, I've created this pull request.

I've implemented only OSX support, but I think it should be relatively easy to
accomplish the same thing for other GNU/Linux desktop environments (actually,
it should be incredibly simple to adapt the Ratpoison script for which this branch
is based on).

Notice there might be still some rough edges, as I didn't worry about handling
errors in case the user hasn't configured the OS navigation part, so if there is
still interest in this pull request, it might be necessary to polish before merging.

What do you think?