### PR TITLE
Consume error thrown when autosaving file without name

### DIFF
--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -68,7 +68,10 @@ function! s:TmuxAwareNavigate(direction)
   " b) we tried switching windows in vim but it didn't have effect.
   if tmux_last_pane || nr == winnr()
     if g:tmux_navigator_save_on_switch
-      update
+      try
+        update
+      catch /^Vim\%((\a\+)\)\=:E32/
+      endtry
     endif
     let args = 'select-pane -' . tr(a:direction, 'phjkl', 'lLDUR')
     silent call s:TmuxCommand(args)


### PR DESCRIPTION
Summary: Fixes #142. An issue existed where opening vim without a file
path and then navigating away (with autosave turned on) resulted in an
error being thrown. Now, this error is caught and consumed and not
propagated to the user.

Test Plan:
1) Started up a vim instance without a file path.
2) Created a second tmux pane.
3) navigated to tmux pane with vim
4) entered insert mode and wrote some gibberish
5) navigated away from the tmux pane containing the vim instance
6) no error message was shown to me

Please review the hell out of this, commit message included. It's been a while since I contributed to a project on github and I've literally never written vimscript before.