### PR TITLE
Add new option to auto save all buffers on navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,19 @@ Left would be created with `nnoremap <silent> <c-h> :TmuxNavigateLeft<cr>`.
 
 ##### Autosave on leave
 
-    let g:tmux_navigator_save_on_switch = 1
+You can configure the plugin to write the current buffer, or all buffers, when navigating from Vim to tmux. This functionality is exposed via the `g:tmux_navigator_save_on_switch` variable, which can have either of the following values:
 
-This will execute the update command on leaving vim to a tmux pane. Default is Zero
+Value  | Behavior
+------ | ------
+1      | `:update` (write the current buffer, but only if changed)
+2      | `:wall` (write all buffers)
+
+To enable this, add the following (with the desired value) to your ~/.vimrc:
+
+```vim
+" Write all buffers before navigating from Vim to tmux pane
+let g:tmux_navigator_save_on_switch = 2
+```
 
 #### Tmux
 

--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -67,10 +67,15 @@ function! s:TmuxAwareNavigate(direction)
   " a) we're toggling between the last tmux pane;
   " b) we tried switching windows in vim but it didn't have effect.
   if tmux_last_pane || nr == winnr()
-    if g:tmux_navigator_save_on_switch
+    if g:tmux_navigator_save_on_switch == 1
       try
-        update
-      catch /^Vim\%((\a\+)\)\=:E32/
+        update " save the active buffer. See :help update
+      catch /^Vim\%((\a\+)\)\=:E32/ " catches the no file name error 
+      endtry
+    elseif g:tmux_navigator_save_on_switch == 2
+      try
+        wall " save all the buffers. See :help wall
+      catch /^Vim\%((\a\+)\)\=:E141/ " catches the no file name error 
       endtry
     endif
     let args = 'select-pane -t ' . $TMUX_PANE . ' -' . tr(a:direction, 'phjkl', 'lLDUR')


### PR DESCRIPTION
Summary: Added a new option which, when set, causes all open and changed
buffers to be written when navigating away from a vim session. If auto
save is turned on and this option is turned off, only the active buffer
gets saved.

Test Plan:
1) Open up two tmux panes, one running vim and the other not
2) In the vim pane open several files and modify each of them without
explicitly writing any of them
3) navigate away from the tmux split containing vim
4) navigate back to the tmux split containing vim
5) write all files with ":wa"
6) see that nothing got written suggesting that every buffer was written
in step 3

1) enable new option
2) open two tmux splits
3) in one of the splits open vim without a file name. (just `vim` not
`vim <some-file-path>`)
4) enter text into the vim instance
5) navigate away from tmux pnae containing unnamed vim
6) see that no error is shown to user