### PR TITLE
Fix switching panes when multiple sessions are attached to the same window(s).

### DIFF
--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -73,7 +73,7 @@ function! s:TmuxAwareNavigate(direction)
       catch /^Vim\%((\a\+)\)\=:E32/
       endtry
     endif
-    let args = 'select-pane -' . tr(a:direction, 'phjkl', 'lLDUR')
+    let args = 'select-pane -t ' . $TMUX_PANE . ' -' . tr(a:direction, 'phjkl', 'lLDUR')
     silent call s:TmuxCommand(args)
     if s:NeedsVitalityRedraw()
       redraw!


### PR DESCRIPTION
I run several tmux sessions all pointed at the same source session (one in a windowed terminal, one in fullscreen, and sometimes one via ssh from another machine). This patch uses the `TMUX_PANE` environment variable in the `select-window` command to help tmux understand which window you want to change the selection in. Otherwise, the command only works from one of the sessions.

(I did look at fetching it with `display-message -p '{#D}'` but oddly that seemed to return nothing sometimes.)

My first vimscript hacking, hope I did it right!