### PR TITLE
Escape the % in the tmux select-pane -t command to prevent process substitution by fish

### DIFF
--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -78,7 +78,7 @@ function! s:TmuxAwareNavigate(direction)
       catch /^Vim\%((\a\+)\)\=:E141/ " catches the no file name error 
       endtry
     endif
-    let args = 'select-pane -t ' . $TMUX_PANE . ' -' . tr(a:direction, 'phjkl', 'lLDUR')
+    let args = 'select-pane -t \' . $TMUX_PANE . ' -' . tr(a:direction, 'phjkl', 'lLDUR')
     silent call s:TmuxCommand(args)
     if s:NeedsVitalityRedraw()
       redraw!

--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -78,7 +78,7 @@ function! s:TmuxAwareNavigate(direction)
       catch /^Vim\%((\a\+)\)\=:E141/ " catches the no file name error 
       endtry
     endif
-    let args = 'select-pane -t \' . $TMUX_PANE . ' -' . tr(a:direction, 'phjkl', 'lLDUR')
+    let args = 'select-pane -t ' . shellescape($TMUX_PANE) . ' -' . tr(a:direction, 'phjkl', 'lLDUR')
     silent call s:TmuxCommand(args)
     if s:NeedsVitalityRedraw()
       redraw!


### PR DESCRIPTION
Re #148 