### PR TITLE
Added nested navigation support!

### DIFF
--- a/scripts/helpers/direction_utils.sh
+++ b/scripts/helpers/direction_utils.sh
@@ -1,0 +1,115 @@
+function window_height() {
+  tmux display-message -p "#{window_height}"
+}
+
+function window_width() {
+  tmux display-message -p "#{window_width}"
+}
+
+function pane_top() {
+  tmux display-message -p "#{pane_top}"
+}
+
+function pane_bottom() {
+  tmux display-message -p "#{pane_bottom}"
+}
+
+function pane_left() {
+  tmux display-message -p "#{pane_left}"
+}
+
+function pane_right() {
+  tmux display-message -p "#{pane_right}"
+}
+
+function pane_index() {
+  tmux display-message -p "#{pane_index}"
+}
+
+function is_bounded() {
+  tmux show-options -g @navigation-bounded &> /dev/null || return 1
+}
+
+function can_select_pane() {
+  if is_bounded || is_nested; then
+    case $1 in
+      L)
+        [[ $(pane_left) -gt 0 ]]
+        ;;
+      R)
+        [[ $(pane_right) -lt $(($(window_width) - 1)) ]]
+        ;;
+      U)
+        [[ $(pane_top) -gt 0 ]]
+        ;;
+      D)
+        [[ $(pane_bottom) -lt $(($(window_height) - 1)) ]]
+        ;;
+    esac
+  fi
+}
+
+function select_pane() {
+  case $1 in
+    L)
+      is_nested && select_pane_left || tmux select-pane -L
+      ;;
+    R)
+      is_nested && select_pane_right || tmux select-pane -R
+      ;;
+    U)
+      is_nested && select_pane_up || tmux select-pane -U
+      ;;
+    D)
+      is_nested && select_pane_down || tmux select-pane -D
+      ;;
+  esac
+}
+
+function select_pane_dir() {
+  local bound dir index lower offset op pane pos selected upper
+  op=$1
+  dir=$2
+  bound=$3
+  lower=$4
+  upper=$5
+  offset=$6
+
+  IFS=',' read pane dir pos offset <<< \
+    $(tmux display-message -p "#{pane_index},#{pane_$dir},#{pane_$upper},#{cursor_$offset}")
+  pos=$(($pos + $offset))
+
+  panes=("$(tmux list-panes \
+    -F "#{pane_index},#{pane_$upper},#{pane_$lower},#{pane_$bound}")")
+  for p in ${panes[@]}; do
+    IFS=',' read index upper lower bound <<< $p
+    [[ $index -eq $pane ]] && continue
+
+    if [[ $pos -ge $upper ]] && [[ $pos -le $lower ]]; then
+      if [[ $(($dir $op 2)) -eq $bound ]]; then
+        selected=$index
+        break
+      fi
+    fi
+  done
+
+  if [ $selected ]; then
+    tmux select-pane -t $selected
+  fi
+}
+
+function select_pane_left() {
+  select_pane_dir "-" "left" "right" "bottom" "top" "y"
+}                                    
+                                     
+function select_pane_right() {       
+  select_pane_dir "+" "right" "left" "bottom" "top" "y"
+}                                    
+                                     
+function select_pane_up() {          
+  select_pane_dir "-" "top" "bottom" "right" "left" "x"
+}                                    
+                                     
+function select_pane_down() {        
+  select_pane_dir "+" "bottom" "top" "right" "left" "x"
+}

--- a/scripts/helpers/nesting_utils.sh
+++ b/scripts/helpers/nesting_utils.sh
@@ -1,0 +1,7 @@
+function allow_nested() {
+  tmux show-options -g @navigation-nested &> /dev/null || return 1
+}
+
+function is_nested() {
+  allow_nested && $CURRENT_DIR/is-running "ssh|tmux"
+}

--- a/scripts/if-nested
+++ b/scripts/if-nested
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+HELPERS_DIR="$CURRENT_DIR/helpers"
+
+source "$HELPERS_DIR/direction_utils.sh"
+source "$HELPERS_DIR/nesting_utils.sh"
+
+function get_cursor_pos() {
+  tmux display-message -p '#{cursor_x},#{cursor_y}'
+}
+
+function navigation_delay() {
+  tmux show-options -gv @navigation-delay 2> /dev/null || return 0.2
+}
+
+function main() {
+  local cursor dir key
+
+  key="$1"
+  dir="$2"
+
+  cursor="$(get_cursor_pos)"
+  if is_nested; then
+    tmux send-keys C-$key
+    if $CURRENT_DIR/is-running "ssh"; then
+      sleep $(navigation_delay)
+    fi
+  fi
+
+  if can_select_pane $dir && [[ "$cursor" == "$(get_cursor_pos)" ]]; then
+    select_pane $dir
+  fi
+}
+
+main "$@"

--- a/scripts/is-running
+++ b/scripts/is-running
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+function get_tty() {
+  tmux display-message -p "#{pane_tty}"
+}
+
+function main() {
+  ps -o state= -o comm= -t "$(get_tty)" \
+    | grep -iqE "^[^TXZ ]+ +(\\S+\\/)?g?($1)(diff)?$"
+}
+
+main "$@"

--- a/vim-tmux-navigator.tmux
+++ b/vim-tmux-navigator.tmux
@@ -1,9 +1,20 @@
 #!/usr/bin/env bash
 
-is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
-    | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$'"
-tmux bind-key -n C-h if-shell "$is_vim" "send-keys C-h"  "select-pane -L"
-tmux bind-key -n C-j if-shell "$is_vim" "send-keys C-j"  "select-pane -D"
-tmux bind-key -n C-k if-shell "$is_vim" "send-keys C-k"  "select-pane -U"
-tmux bind-key -n C-l if-shell "$is_vim" "send-keys C-l"  "select-pane -R"
-tmux bind-key -n C-\\ if-shell "$is_vim" "send-keys C-\\" "select-pane -l"
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SCRIPTS_DIR="$CURRENT_DIR/scripts"
+
+function navigation_setup() {
+  local after bindkey cursor dir key isvim query select
+
+  dir="$2"
+  key="$(printf "%q" "$1")"
+
+  tmux bind-key -n C-$1 if-shell "$SCRIPTS_DIR/is-running 'view|n?vim?x?'" \
+    "send-keys C-$key" "run-shell '$SCRIPTS_DIR/if-nested $key $dir'"
+}
+
+navigation_setup 'h' 'L'
+navigation_setup 'j' 'D'
+navigation_setup 'k' 'U'
+navigation_setup 'l' 'R'
+navigation_setup '\' 'l'


### PR DESCRIPTION
* Use global option @navigation-bounded to force navigation to not wrap
during motion commands (default 'off').

* Use global option @navigation-nested to allow navigating nested tmux
sessions. This option implies @navigation-bounded as it is required for
proper nested navigation behavior (default 'off').

* Use global option @navigation-delay to specify a larger or smaller
delay between issuing the movement command and executing it over ssh.
Larger values might be needed if high latency ssh sessions are in use.
(default '0.2').

This has been tested both on locally nested tmux sessions (using `TMUX= tmux`
to get around nested sessions warnings) and on nested tmux/ssh
sessions. It seems to work fine on two levels of nesting, but I have
noticed quirks at higher nesting levels. I have not put in the time and
effort to fix those as I do not currently have a usecase.

Thanks so much for the work you put in for this great plugin. I do not have too
much time to help usher this pull request through. In fact I still have a mini
feature I made in my .vimrc for [neomake](https://github.com/neomake/neomake) that I have not had the time to package
up into a pull request. That said I will try my best.

Hopefully with this feature you will get to remove this from your README:
> If you like to nest your tmux sessions, this plugin is not going to work properly.
> It probably never will...

😉