### PR TITLE
Configurable moving out of zoomed tmux pane

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,12 @@ Alter each of the five lines of the tmux configuration listed above to use your
 custom mappings. **Note** each line contains two references to the desired
 mapping.
 
+#### Moving out of zoomed Tmux pane
+
+    let g:tmux_navigator_zoom_out_navigation = 1
+
+This will enable moving out of zoomed Tmux pane. Default is `0`.
+
 ### Additional Customization
 
 #### Restoring Clear Screen (C-l)

--- a/doc/tmux-navigator.txt
+++ b/doc/tmux-navigator.txt
@@ -24,6 +24,9 @@ CONFIGURATION                             *tmux-navigator-configuration*
 * Custom Key Bindings
  let g:tmux_navigator_no_mappings = 1
 
+* Activate moving out from zoomed tmux pane
+ let g:tmux_navigator_zoom_out_navigation = 1
+
  nnoremap <silent> {Left-mapping} :TmuxNavigateLeft<cr>
  nnoremap <silent> {Down-Mapping} :TmuxNavigateDown<cr>
  nnoremap <silent> {Up-Mapping} :TmuxNavigateUp<cr>

--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -11,6 +11,10 @@ if !exists("g:tmux_navigator_save_on_switch")
   let g:tmux_navigator_save_on_switch = 0
 endif
 
+if !exists("g:tmux_navigator_zoom_out_navigation")
+  let g:tmux_navigator_zoom_out_navigation = 0
+endif
+
 function! s:TmuxOrTmateExecutable()
   return (match($TMUX, 'tmate') != -1 ? 'tmate' : 'tmux')
 endfunction
@@ -38,10 +42,10 @@ function! s:TmuxPaneCurrentCommand()
 endfunction
 command! TmuxPaneCurrentCommand call s:TmuxPaneCurrentCommand()
 
-let s:tmux_is_last_pane = 0
+let s:last_navigated_to = "vim"
 augroup tmux_navigator
   au!
-  autocmd WinEnter * let s:tmux_is_last_pane = 0
+  autocmd WinEnter * let s:last_navigated_to = "vim"
 augroup END
 
 " Like `wincmd` but also change tmux panes instead of vim windows when needed.
@@ -57,44 +61,58 @@ function! s:NeedsVitalityRedraw()
   return exists('g:loaded_vitality') && v:version < 704 && !has("patch481")
 endfunction
 
+function! s:TmuxIsPaneZoomed()
+    call system(s:TmuxOrTmateExecutable().' display -p "#{window_zoomed_flag}" | grep -q 1')
+    return v:shell_error == 0
+endfunction
+
 function! s:TmuxAwareNavigate(direction)
-  let nr = winnr()
-  let tmux_last_pane = (a:direction == 'p' && s:tmux_is_last_pane)
-  if !tmux_last_pane
-    call s:VimNavigate(a:direction)
-  endif
+  let is_toggling_to_tmux =  a:direction == 'p' && s:last_navigated_to == "tmux"
+  let can_move_out_of_vim = s:TmuxIsPaneZoomed() ? g:tmux_navigator_zoom_out_navigation : 1 
+  
   " Forward the switch panes command to tmux if:
   " a) we're toggling between the last tmux pane;
   " b) we tried switching windows in vim but it didn't have effect.
-  if tmux_last_pane || nr == winnr()
-    if g:tmux_navigator_save_on_switch == 1
-      try
-        update " save the active buffer. See :help update
-      catch /^Vim\%((\a\+)\)\=:E32/ " catches the no file name error 
-      endtry
-    elseif g:tmux_navigator_save_on_switch == 2
-      try
-        wall " save all the buffers. See :help wall
-      catch /^Vim\%((\a\+)\)\=:E141/ " catches the no file name error 
-      endtry
-    endif
-    let args = 'select-pane -t ' . shellescape($TMUX_PANE) . ' -' . tr(a:direction, 'phjkl', 'lLDUR')
-    silent call s:TmuxCommand(args)
-    if s:NeedsVitalityRedraw()
-      redraw!
-    endif
-    let s:tmux_is_last_pane = 1
-  else
-    let s:tmux_is_last_pane = 0
+  if is_toggling_to_tmux == 0 && s:VimNavigate(a:direction) == 1
+    let s:last_navigated_to = "vim"
+  elseif can_move_out_of_vim == 1
+    call s:TmuxNavigate(a:direction)
+    let s:last_navigated_to = "tmux"
   endif
 endfunction
 
+function! s:TmuxNavigate(direction)
+  if g:tmux_navigator_save_on_switch == 1
+    try
+      update " save the active buffer. See :help update
+    catch /^Vim\%((\a\+)\)\=:E32/ " catches the no file name error 
+    endtry
+  elseif g:tmux_navigator_save_on_switch == 2
+    try
+      wall " save all the buffers. See :help wall
+    catch /^Vim\%((\a\+)\)\=:E141/ " catches the no file name error 
+    endtry
+  endif
+
+  let args = 'select-pane -t ' . shellescape($TMUX_PANE) . ' -' . tr(a:direction, 'phjkl', 'lLDUR')
+  silent call s:TmuxCommand(args)
+
+  if s:NeedsVitalityRedraw()
+    redraw!
+  endif
+endfunction
+
+" returns `1` if navigated to another vim window, otherwise returns `0`
 function! s:VimNavigate(direction)
+  let nr = winnr()
+
   try
     execute 'wincmd ' . a:direction
   catch
     echohl ErrorMsg | echo 'E11: Invalid in command-line window; <CR> executes, CTRL-C quits: wincmd k' | echohl None
   endtry
+
+  return nr != winnr()
 endfunction
 
 command! TmuxNavigateLeft call s:TmuxWinCmd('h')


### PR DESCRIPTION
Hi

Initially I created PR #152. There I explained why people may need to prevent moving out of zoomed tmux pane. #152 had some shortcomings that are fixed in this PR:
- added option for switching on/off moving out of zoomed tmux pane.
- documentation added.
- code made more clear and more readable.

I know that there is a PR #133 which is doing the same but I think that solution from this PR has some disadvantages:
1. key press timeouts is a complex approach, it would be better to keep things simple and straightforward by just having ability to enable/disable moving out from zoomed tmux pane.
2. code is complex and not readable

From #133 I know that some people think that working in a zoomed tmux pane is anti-pattern. I completely disagree with this statement, I find pane zooming extremely useful on small size screens. From #133 I know that there are people who also find zoom feature useful. I think that it's person's choice to decide if he or she want to use this feature or not. The problem is that pane zooming is a tmux feature and vim-tmux-navigator handles it only in a single way while there are at least 2 ways. Moreover, I find prevent moving out from zoomed pane more natural then allowing to do it. When I'm in a zoomed pane I want to focus on this pane only and I don't want to accidentally leave it. The only reason for zooming out should be explicit call of `zoom out` command.
