### PR TITLE
Add option to disable tmux navigation while zoomed

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,24 @@ To enable this, add the following (with the desired value) to your ~/.vimrc:
 let g:tmux_navigator_save_on_switch = 2
 ```
 
+##### Disable While Zoomed
+
+By default, if you zoom the tmux pane running Vim and then attempt to navigate
+"past" the edge of the Vim session, tmux will unzoom the pane. This is the
+default tmux behavior, but may be confusing if you've become accustomed to
+navigation "wrapping" around the sides due to this plugin.
+
+We provide an option, `g:tmux_navigator_disable_when_zoomed`, which can be used
+to disable this unzooming behavior, keeping all navigation within Vim until the
+tmux pane is explicitly unzoomed.
+
+To disable navigation when zoomed, add the following to your ~/.vimrc:
+
+```vim
+" Disable tmux navigator when zooming the Vim pane
+let g:tmux_navigator_disable_when_zoomed = 1
+```
+
 #### Tmux
 
 Alter each of the five lines of the tmux configuration listed above to use your

--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -11,6 +11,10 @@ if !exists("g:tmux_navigator_save_on_switch")
   let g:tmux_navigator_save_on_switch = 0
 endif
 
+if !exists("g:tmux_navigator_disable_when_zoomed")
+  let g:tmux_navigator_disable_when_zoomed = 0
+endif
+
 function! s:TmuxOrTmateExecutable()
   return (match($TMUX, 'tmate') != -1 ? 'tmate' : 'tmux')
 endfunction
@@ -21,6 +25,10 @@ endfunction
 
 function! s:InTmuxSession()
   return $TMUX != ''
+endfunction
+
+function! s:TmuxVimPaneIsZoomed()
+  return s:TmuxCommand("display-message -p '#{window_zoomed_flag}'") == 1
 endfunction
 
 function! s:TmuxSocket()
@@ -57,25 +65,33 @@ function! s:NeedsVitalityRedraw()
   return exists('g:loaded_vitality') && v:version < 704 && !has("patch481")
 endfunction
 
+function! s:ShouldForwardNavigationBackToTmux(tmux_last_pane, at_tab_page_edge)
+  if g:tmux_navigator_disable_when_zoomed && s:TmuxVimPaneIsZoomed()
+    return 0
+  endif
+  return a:tmux_last_pane || a:at_tab_page_edge
+endfunction
+
 function! s:TmuxAwareNavigate(direction)
   let nr = winnr()
   let tmux_last_pane = (a:direction == 'p' && s:tmux_is_last_pane)
   if !tmux_last_pane
     call s:VimNavigate(a:direction)
   endif
+  let at_tab_page_edge = (nr == winnr())
   " Forward the switch panes command to tmux if:
   " a) we're toggling between the last tmux pane;
   " b) we tried switching windows in vim but it didn't have effect.
-  if tmux_last_pane || nr == winnr()
+  if s:ShouldForwardNavigationBackToTmux(tmux_last_pane, at_tab_page_edge)
     if g:tmux_navigator_save_on_switch == 1
       try
         update " save the active buffer. See :help update
-      catch /^Vim\%((\a\+)\)\=:E32/ " catches the no file name error 
+      catch /^Vim\%((\a\+)\)\=:E32/ " catches the no file name error
       endtry
     elseif g:tmux_navigator_save_on_switch == 2
       try
         wall " save all the buffers. See :help wall
-      catch /^Vim\%((\a\+)\)\=:E141/ " catches the no file name error 
+      catch /^Vim\%((\a\+)\)\=:E141/ " catches the no file name error
       endtry
     endif
     let args = 'select-pane -t ' . shellescape($TMUX_PANE) . ' -' . tr(a:direction, 'phjkl', 'lLDUR')


### PR DESCRIPTION
Users have requested the ability to disable navigation while the Vim
tmux pane is zoomed, to prevent accidentally unzooming the pane when
navigating past the edges.

This change adds an option to prevent using tmux navigation when the Vim
pane is zoomed, and requiring an explicit unzooming of the tmux pane
before the plugin resumes its magic.

-------

Preventing navigation has been requested a number of times in this repo (#56, #104, #65, #151, and most recently #133 and #156).

I've consistently resisted adding support for this as I felt that working within a zoomed pane is not an optimal workflow and would add undue complexity, but based on the quantity of requests for this feature, I realize this is something that a number of people want, and this code is my attempt to provide a solution while adding as little complexity as possible.

I've opted for a simple and direct implementation, largely based on @glentakahashi's solution presented in #104. To sum up the changes:

- `g:tmux_navigator_disable_when_zoomed` is provided as a new option
- The config is off by default so as to not be a breaking change
- When set to `1`, we prevent navigating out of Vim when zoomed
- To return to normal behavior, the user unzooms the pane

Thanks all for the contributions, suggestions, and patience :)