### PR TITLE
Add option to issue display-panes command on leaving Vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,15 @@ To disable navigation when zoomed, add the following to your ~/.vimrc:
 let g:tmux_navigator_disable_when_zoomed = 1
 ```
 
+##### Use display-panes Command on leave
+
+You can configure the plugin to also emit the `display-panes` command to tmux when leaving Vim. This will display an overlay helping to find the target (e.g. in case there are multiple splits below/beside Vim).
+
+```vim
+" Display overlay with target pane
+let g:tmux_navigator_display_panes = 1
+```
+
 #### Tmux
 
 Alter each of the five lines of the tmux configuration listed above to use your

--- a/doc/tmux-navigator.txt
+++ b/doc/tmux-navigator.txt
@@ -24,6 +24,9 @@ CONFIGURATION                             *tmux-navigator-configuration*
 * Custom Key Bindings
  let g:tmux_navigator_no_mappings = 1
 
+* Activate display-panes command on switching out of vim
+ let g:tmux_navigator_display_panes = 1
+
  nnoremap <silent> {Left-mapping} :TmuxNavigateLeft<cr>
  nnoremap <silent> {Down-Mapping} :TmuxNavigateDown<cr>
  nnoremap <silent> {Up-Mapping} :TmuxNavigateUp<cr>

--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -15,6 +15,10 @@ if !exists("g:tmux_navigator_disable_when_zoomed")
   let g:tmux_navigator_disable_when_zoomed = 0
 endif
 
+if !exists("g:tmux_navigator_diplay_panes")
+  let g:tmux_navigator_diplay_panes = 0
+endif
+
 function! s:TmuxOrTmateExecutable()
   return (match($TMUX, 'tmate') != -1 ? 'tmate' : 'tmux')
 endfunction
@@ -95,6 +99,9 @@ function! s:TmuxAwareNavigate(direction)
       endtry
     endif
     let args = 'select-pane -t ' . shellescape($TMUX_PANE) . ' -' . tr(a:direction, 'phjkl', 'lLDUR')
+    if g:tmux_navigator_diplay_panes
+       let args = 'display-panes \; '. args
+    endif
     silent call s:TmuxCommand(args)
     if s:NeedsVitalityRedraw()
       redraw!


### PR DESCRIPTION
This makes it a lot easier to find out where you land coming from Vim if there are multiple splits below/beside of Vim.