### PR TITLE
Detect Nix wrapped vim

### DIFF
--- a/vim-tmux-navigator.tmux
+++ b/vim-tmux-navigator.tmux
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
-    | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$'"
+    | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|\.?n?vim?x?(-wrapped)?)(diff)?$'"
 tmux bind-key -n C-h if-shell "$is_vim" "send-keys C-h"  "select-pane -L"
 tmux bind-key -n C-j if-shell "$is_vim" "send-keys C-j"  "select-pane -D"
 tmux bind-key -n C-k if-shell "$is_vim" "send-keys C-k"  "select-pane -U"


### PR DESCRIPTION
This plugin doesn't work in Nix/NixOS because of the way that binaries are
wrapped:

```
$ ps -o state= -o comm= -t /dev/pts/9
S zsh
S .nvim-wrapped
S python3
```

This change tweaks the pattern slightly to accommodate that.