### PR TITLE
[RFC] implement tmux 2.4 compatibility, fixes #159

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ bind-key -n C-j if-shell "$is_vim" "send-keys C-j"  "select-pane -D"
 bind-key -n C-k if-shell "$is_vim" "send-keys C-k"  "select-pane -U"
 bind-key -n C-l if-shell "$is_vim" "send-keys C-l"  "select-pane -R"
 bind-key -n C-\ if-shell "$is_vim" "send-keys C-\\" "select-pane -l"
+bind-key -T copy-mode-vi C-h select-pane -L
+bind-key -T copy-mode-vi C-j select-pane -D
+bind-key -T copy-mode-vi C-k select-pane -U
+bind-key -T copy-mode-vi C-l select-pane -R
+bind-key -T copy-mode-vi C-\ select-pane -l
 ```
 
 #### TPM

--- a/vim-tmux-navigator.tmux
+++ b/vim-tmux-navigator.tmux
@@ -7,3 +7,8 @@ tmux bind-key -n C-j if-shell "$is_vim" "send-keys C-j"  "select-pane -D"
 tmux bind-key -n C-k if-shell "$is_vim" "send-keys C-k"  "select-pane -U"
 tmux bind-key -n C-l if-shell "$is_vim" "send-keys C-l"  "select-pane -R"
 tmux bind-key -n C-\\ if-shell "$is_vim" "send-keys C-\\" "select-pane -l"
+tmux bind-key -T copy-mode-vi C-h select-pane -L
+tmux bind-key -T copy-mode-vi C-j select-pane -D
+tmux bind-key -T copy-mode-vi C-k select-pane -U
+tmux bind-key -T copy-mode-vi C-l select-pane -R
+tmux bind-key -T copy-mode-vi C-\ select-pane -l


### PR DESCRIPTION
See: [changes from 2.3 to 2.4 20 April 2017](https://github.com/tmux/tmux/blob/master/CHANGES). The bindings <kbd>C-h</kbd>, <kbd>C-j</kbd>, <kbd>C-k</kbd> and <kbd>C-l</kbd> are broken in tmux 2.4 *copy-mode*.

This code is a step up from having your cursor frozen in Vim while in tmux 2.4 copy-mode, but I had to remove the `if-shell` part of the script. Don't know why.