### PR TITLE
Revert extra shell escaping in non-TPM bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ bind-key -n C-h if-shell "$is_vim" "send-keys C-h"  "select-pane -L"
 bind-key -n C-j if-shell "$is_vim" "send-keys C-j"  "select-pane -D"
 bind-key -n C-k if-shell "$is_vim" "send-keys C-k"  "select-pane -U"
 bind-key -n C-l if-shell "$is_vim" "send-keys C-l"  "select-pane -R"
-bind-key -n C-\\ if-shell "$is_vim" "send-keys C-\\" "select-pane -l"
+bind-key -n C-\ if-shell "$is_vim" "send-keys C-\\" "select-pane -l"
 bind-key -T copy-mode-vi C-h select-pane -L
 bind-key -T copy-mode-vi C-j select-pane -D
 bind-key -T copy-mode-vi C-k select-pane -U
 bind-key -T copy-mode-vi C-l select-pane -R
-bind-key -T copy-mode-vi C-\\ select-pane -l
+bind-key -T copy-mode-vi C-\ select-pane -l
 ```
 
 #### TPM
@@ -196,7 +196,7 @@ bind -r C-h run "tmux select-pane -L"
 bind -r C-j run "tmux select-pane -D"
 bind -r C-k run "tmux select-pane -U"
 bind -r C-l run "tmux select-pane -R"
-bind -r C-\\ run "tmux select-pane -l"
+bind -r C-\ run "tmux select-pane -l"
 ```
 
 Troubleshooting


### PR DESCRIPTION
Why
---

https://github.com/christoomey/vim-tmux-navigator/pull/181 was
introduced to fix an issues with the TPM install script not running
cleanly. This was due to the `C-\` key binding not being properly
escaped in the final line of the script.

In the process of fixing this in #181, it looks like we took it a bit
overboard and escaped _all_ `C-\` sequences. In the end, the others
should not be escaped, so this was causing issues for users not
configuring via TPM script.

This change
-----------

This change reverts all of the `C-\` escaping outside of the TPM script.