### PR TITLE
Add ability to extend matching pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,10 @@ the innermost tmux session and the vim sessions within that one. This works
 better than the default behaviour if you use the outer Tmux sessions as relays
 to different hosts and have all instances of vim on remote hosts.
 
+To easily extend the default pattern, you may use the `$VIM_TMUX_NAV_PAT`
+environment variable, and assign your custom pattern to it. To make it work,
+only make sure that the variable is exported before launching Tmux.
+
 Similarly, if you like to nest tmux locally, add `|tmux` to the expression.
 
 This behaviour means that you can't leave the innermost session with Ctrl-hjkl

--- a/vim-tmux-navigator.tmux
+++ b/vim-tmux-navigator.tmux
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 
+if [ -z "$VIM_TMUX_NAV_PAT" ]
+then
+    VIM_TMUX_NAV_PAT="(\\S+\\/)?g?(view|n?vim?x?)(diff)?"
+fi
+
 is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
-    | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$'"
+    | grep -iqE '^[^TXZ ]+ +${VIM_TMUX_NAV_PAT}$'"
 tmux bind-key -n C-h if-shell "$is_vim" "send-keys C-h"  "select-pane -L"
 tmux bind-key -n C-j if-shell "$is_vim" "send-keys C-j"  "select-pane -D"
 tmux bind-key -n C-k if-shell "$is_vim" "send-keys C-k"  "select-pane -U"


### PR DESCRIPTION
As described in the **Nesting** section, one might want to extend the process name matching pattern, in order to capture `ssh`, `mosh` or `vagrant` in case of nesting.

To make that option easier, let's provide and environment variable to enable the extension with the default value set as the original one.