### PR TITLE
[WIP] Use tmux variable to indicate running Vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,12 @@ Add the following to your `~/.tmux.conf` file:
 ``` tmux
 # Smart pane switching with awareness of Vim splits.
 # See: https://github.com/christoomey/vim-tmux-navigator
-is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
-    | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$'"
-bind-key -n C-h if-shell "$is_vim" "send-keys C-h"  "select-pane -L"
-bind-key -n C-j if-shell "$is_vim" "send-keys C-j"  "select-pane -D"
-bind-key -n C-k if-shell "$is_vim" "send-keys C-k"  "select-pane -U"
-bind-key -n C-l if-shell "$is_vim" "send-keys C-l"  "select-pane -R"
-bind-key -n C-\ if-shell "$is_vim" "send-keys C-\\" "select-pane -l"
+bind-key -n C-h if-shell -F '#{m:*-#{pane_id}-*,#{@tmux_navigator}}' 'send-keys C-h' 'select-pane -L'
+bind-key -n C-j if-shell -F '#{m:*-#{pane_id}-*,#{@tmux_navigator}}' 'send-keys C-j' 'select-pane -D'
+bind-key -n C-k if-shell -F '#{m:*-#{pane_id}-*,#{@tmux_navigator}}' 'send-keys C-k' 'select-pane -U'
+bind-key -n C-l if-shell -F '#{m:*-#{pane_id}-*,#{@tmux_navigator}}' 'send-keys C-l' 'select-pane -R'
+bind-key -n C-\ if-shell -F '#{m:*-#{pane_id}-*,#{@tmux_navigator}}' 'send-keys C-\\' 'select-pane -l'
+
 bind-key -T copy-mode-vi C-h select-pane -L
 bind-key -T copy-mode-vi C-j select-pane -D
 bind-key -T copy-mode-vi C-k select-pane -U

--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -139,13 +139,19 @@ else
   let s:async_f = 'system'
 endif
 
+function! s:get_indicator() abort
+  return s:TmuxCommand(['show', '-v', '@tmux_navigator'])
+endfunction
+command! TmuxNavigatorPaneIndicator echo s:get_indicator()
+
 function! s:setup_indicator() abort
   call call(s:async_f, [s:GetTmuxCommand(['set', '-a', '@tmux_navigator', '-'.$TMUX_PANE.'-'])])
 endfunction
 
 function! s:remove_indicator() abort
-  let cur = s:TmuxCommand(['show', '-v', '@tmux_navigator'])
-  let new = substitute(cur, '-'.$TMUX_PANE.'-', '', '')
+  let cur = s:get_indicator()
+  " Remove indicators globally (especially important with nested Vim in :term).
+  let new = substitute(cur, '-'.$TMUX_PANE.'-', '', 'g')
   call call(s:async_f, [s:GetTmuxCommand(['set', '@tmux_navigator', new])])
 endfunction
 

--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -51,7 +51,7 @@ function! s:TmuxOrTmateExecutable()
 endfunction
 
 function! s:TmuxVimPaneIsZoomed()
-  return s:TmuxCommand("display-message -p '#{window_zoomed_flag}'") == 1
+  return s:TmuxCommand(['display-message', '-p', '#{window_zoomed_flag}']) == 1
 endfunction
 
 function! s:TmuxSocket()
@@ -59,13 +59,17 @@ function! s:TmuxSocket()
   return split($TMUX, ',')[0]
 endfunction
 
+function! s:GetTmuxCommand(args)
+  return [s:TmuxOrTmateExecutable(), '-S', s:TmuxSocket()] + a:args
+endfunction
+
 function! s:TmuxCommand(args)
-  let cmd = s:TmuxOrTmateExecutable() . ' -S ' . s:TmuxSocket() . ' ' . a:args
-  return system(cmd)
+  let cmd = s:GetTmuxCommand(a:args)
+  return substitute(system(cmd), '\n$', '', '')
 endfunction
 
 function! s:TmuxNavigatorProcessList()
-  echo s:TmuxCommand("run-shell 'ps -o state= -o comm= -t ''''#{pane_tty}'''''")
+  echo s:TmuxCommand(['run-shell', "ps -o state= -o comm= -t '#{pane_tty}'"])
 endfunction
 command! TmuxNavigatorProcessList call s:TmuxNavigatorProcessList()
 
@@ -108,8 +112,8 @@ function! s:TmuxAwareNavigate(direction)
       catch /^Vim\%((\a\+)\)\=:E141/ " catches the no file name error
       endtry
     endif
-    let args = 'select-pane -t ' . shellescape($TMUX_PANE) . ' -' . tr(a:direction, 'phjkl', 'lLDUR')
-    silent call s:TmuxCommand(args)
+    let args = ['select-pane', '-t', $TMUX_PANE, '-'.tr(a:direction, 'phjkl', 'lLDUR')]
+    call s:TmuxCommand(args)
     if s:NeedsVitalityRedraw()
       redraw!
     endif

--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -132,11 +132,17 @@ endfunction
 
 " Indicate to tmux keybindings that we handle $TMUX_PANE.
 if exists('*jobstart')
-  let s:async_f = 'jobstart'
+  function! s:setup_indicator() abort
+    call call('jobstart', [s:GetTmuxCommand(['set', '-a', '@tmux_navigator', '-'.$TMUX_PANE.'-'])])
+  endfunction
 elseif exists('*job_start')
-  let s:async_f = 'job_start'
+  function! s:setup_indicator() abort
+    call call('job_start', [s:GetTmuxCommand(['set', '-a', '@tmux_navigator', '-'.$TMUX_PANE.'-'])])
+  endfunction
 else
-  let s:async_f = 'system'
+  function! s:setup_indicator() abort
+    call s:TmuxCommand(['set', '-a', '@tmux_navigator', '-'.$TMUX_PANE.'-'])
+  endfunction
 endif
 
 function! s:get_indicator() abort
@@ -144,15 +150,11 @@ function! s:get_indicator() abort
 endfunction
 command! TmuxNavigatorPaneIndicator echo s:get_indicator()
 
-function! s:setup_indicator() abort
-  call call(s:async_f, [s:GetTmuxCommand(['set', '-a', '@tmux_navigator', '-'.$TMUX_PANE.'-'])])
-endfunction
-
 function! s:remove_indicator() abort
   let cur = s:get_indicator()
   " Remove indicators globally (especially important with nested Vim in :term).
   let new = substitute(cur, '-'.$TMUX_PANE.'-', '', 'g')
-  call call(s:async_f, [s:GetTmuxCommand(['set', '@tmux_navigator', new])])
+  call s:TmuxCommand(['set', '@tmux_navigator', new])
 endfunction
 
 augroup tmux_navigator

--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -63,10 +63,17 @@ function! s:GetTmuxCommand(args)
   return [s:TmuxOrTmateExecutable(), '-S', s:TmuxSocket()] + a:args
 endfunction
 
-function! s:TmuxCommand(args)
-  let cmd = s:GetTmuxCommand(a:args)
-  return substitute(system(cmd), '\n$', '', '')
-endfunction
+if has('nvim')
+  function! s:TmuxCommand(args)
+    return substitute(system(s:GetTmuxCommand(a:args)), '\n$', '', '')
+  endfunction
+else
+  function! s:TmuxCommand(args)
+    " Vim does not support a list for `system()`.
+    let cmd = join(map(s:GetTmuxCommand(a:args), 'fnameescape(v:val)'))
+    return substitute(system(cmd), '\n$', '', '')
+  endfunction
+endif
 
 function! s:TmuxNavigatorProcessList()
   echo s:TmuxCommand(['run-shell', "ps -o state= -o comm= -t '#{pane_tty}'"])

--- a/vim-tmux-navigator.tmux
+++ b/vim-tmux-navigator.tmux
@@ -1,12 +1,11 @@
 #!/usr/bin/env bash
 
-is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
-    | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$'"
-tmux bind-key -n C-h if-shell "$is_vim" "send-keys C-h"  "select-pane -L"
-tmux bind-key -n C-j if-shell "$is_vim" "send-keys C-j"  "select-pane -D"
-tmux bind-key -n C-k if-shell "$is_vim" "send-keys C-k"  "select-pane -U"
-tmux bind-key -n C-l if-shell "$is_vim" "send-keys C-l"  "select-pane -R"
-tmux bind-key -n C-\\ if-shell "$is_vim" "send-keys C-\\" "select-pane -l"
+tmux bind-key -n C-h if-shell -F '#{m:*-#{pane_id}-*,#{@tmux_navigator}}' "send-keys C-h" "select-pane -L"
+tmux bind-key -n C-j if-shell -F '#{m:*-#{pane_id}-*,#{@tmux_navigator}}' "send-keys C-j" "select-pane -D"
+tmux bind-key -n C-k if-shell -F '#{m:*-#{pane_id}-*,#{@tmux_navigator}}' "send-keys C-k" "select-pane -U"
+tmux bind-key -n C-l if-shell -F '#{m:*-#{pane_id}-*,#{@tmux_navigator}}' "send-keys C-l" "select-pane -R"
+tmux bind-key -n C-\\ if-shell -F '#{m:*-#{pane_id}-*,#{@tmux_navigator}}' "send-keys C-\\" "select-pane -l"
+
 tmux bind-key -T copy-mode-vi C-h select-pane -L
 tmux bind-key -T copy-mode-vi C-j select-pane -D
 tmux bind-key -T copy-mode-vi C-k select-pane -U


### PR DESCRIPTION
This uses @tmux_navigator to hold a list of tmux panes when
vim-tmux-navigator is running.
It uses VimSuspend/VimResume (available on Neovim) to remove itself when
it is suspended (`Ctrl-z`).

(It could easily get extended to detect if vim-tmux-navigator is not
responding (e.g. when a more-prompt is active), but that would involve
an additional (async) command every time vim-tmux-navigator is used.)

Includes https://github.com/christoomey/vim-tmux-navigator/pull/200.

TODO:
 - [ ] review docs (which mention e.g. "grep pattern", which is removed now)
 - [ ] document / bump minimal tmux version - or can it be fixed?