### PR TITLE
Remove README section about Neovim incompatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,8 +247,8 @@ sources the non-interactive config.
 
 ### It doesn't work in Vim's `terminal` mode
 
-Terminal mode is currently unsupported as adding this plugin's mappings there 
-causes conflict with movement mappings for FZF (it also uses terminal mode). 
+Terminal mode is currently unsupported as adding this plugin's mappings there
+causes conflict with movement mappings for FZF (it also uses terminal mode).
 There's a conversation about this in https://github.com/christoomey/vim-tmux-navigator/pull/172
 
 ### It Doesn't Work in tmate
@@ -261,32 +261,6 @@ issue](https://github.com/christoomey/vim-tmux-navigator/issues/27) for more
 detail.
 
 [tmate]: http://tmate.io/
-
-### It Doesn't Work in Neovim (specifically C-h)
-
-[Neovim][] is a Vim fork. While Neovim is intended to be a drop-in replacement
-for Vim, it does handle some keyboard input differently than Vim does. Some
-users (including those on OS X) may find that all of their pane-switching
-keybindings work with the exception of <kbd>Ctrl</kbd>+<kbd>h</kbd>, which
-instead returns a backspace. The explanation of what is going on vastly exceeds
-the scope of this guide, but you can read the discussion on this Neovim
-[issue][].
-
-The simplest and hackiest solution is to add the following to your Neovim
-`init.vim`, capturing the <kbd>Backspace</kbd> that Neovim receives when
-<kbd>Ctrl</kbd>+<kbd>h</kbd> is typed in normal mode:
-
-```vimL
-nnoremap <silent> <BS> :TmuxNavigateLeft<cr>
-```
-
-A more complete and less-hacky solution would be to update the incorrect
-terminfo entry that is part of the problem on OS X (and some Linux
-distributions) as described in this [comment][].
-
-[Neovim]: https://neovim.io/
-[issue]: https://github.com/neovim/neovim/issues/2048
-[comment]: https://github.com/neovim/neovim/issues/2048#issuecomment-78045837
 
 ### It Still Doesn't Work!!!
 


### PR DESCRIPTION
I've been using Neovim with tmux-navigator with no issues for many months now. I just noticed that the README calls out an incompatibility with Neovim and links to an issue. The issue was called out as fixed in [this](https://github.com/neovim/neovim/issues/2048#issuecomment-269032502) comment.

I think this section can safely be removed from the README.