### PR TITLE
Mention that tmux must be present in PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ configuration described in [this gist][]. When combined with a set of tmux
 key bindings, the plugin will allow you to navigate seamlessly between
 vim and tmux splits using a consistent set of hotkeys.
 
-**NOTE**: This requires tmux v1.8 or higher.
+**NOTE**: This requires tmux v1.8 or higher and tmux must be present in Vim's `PATH`.
 
 Usage
 -----


### PR DESCRIPTION
This plugin didn't work for me, commands wouldn't do anything. E.g. `:TmuxNavigateRight` would simply be a no-op. When running `:TmuxNavigatorProcessList` I got an error:

> /bin/bash: tmux: command not found

After [adding `tmux` to the PATH](https://github.com/nmattia/homies/commit/06aa54743990613f3b53a3bf7334d23ce59acc4a) everything worked.