### PR TITLE
adds fzf compatibility (in shell)

### DIFF
--- a/vim-tmux-navigator.tmux
+++ b/vim-tmux-navigator.tmux
@@ -2,9 +2,11 @@
 
 is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
     | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$'"
+is_fzf="ps -o state= -o comm= -t '#{pane_tty}' \
+  | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?fzf$'"
 tmux bind-key -n C-h if-shell "$is_vim" "send-keys C-h"  "select-pane -L"
-tmux bind-key -n C-j if-shell "$is_vim" "send-keys C-j"  "select-pane -D"
-tmux bind-key -n C-k if-shell "$is_vim" "send-keys C-k"  "select-pane -U"
+tmux bind-key -n C-j if-shell "$is_vim || $is_fzf" "send-keys C-j"  "select-pane -D"
+tmux bind-key -n C-k if-shell "$is_vim || $is_fzf" "send-keys C-k"  "select-pane -U"
 tmux bind-key -n C-l if-shell "$is_vim" "send-keys C-l"  "select-pane -R"
 tmux bind-key -n C-\\ if-shell "$is_vim" "send-keys C-\\" "select-pane -l"
 tmux bind-key -T copy-mode-vi C-h select-pane -L


### PR DESCRIPTION
this adds the ability to use C-j and C-k to navigate between entries that FZF has generated, for example when using C-r to find history items in the shell. This does not address the incompatibility with fzf in vim's term mode addressed on the plugin's readme.