### PR TITLE
Add option and instructions to disable wrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,15 +221,15 @@ to conditionally wrap based on position on screen:
 # See: https://github.com/christoomey/vim-tmux-navigator
 is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
     | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$'"
-bind-key -n C-h if-shell "$is_vim" "send-keys C-h"  "if -F '#{?pane_at_left,0,1}' 'select-pane -L'"
-bind-key -n C-j if-shell "$is_vim" "send-keys C-j"  "if -F '#{?pane_at_bottom,0,1}' 'select-pane -D'"
-bind-key -n C-k if-shell "$is_vim" "send-keys C-k"  "if -F '#{?pane_at_top,0,1}' 'select-pane -U'"
-bind-key -n C-l if-shell "$is_vim" "send-keys C-l"  "if -F '#{?pane_at_right,0,1}' 'select-pane -R'"
+bind-key -n C-h if-shell "$is_vim" "send-keys C-h"  "if-shell 'expr #{pane_left}' 'select-pane -L'"
+bind-key -n C-j if-shell "$is_vim" "send-keys C-j"  "if-shell 'expr #{window_height} - #{pane_bottom} - 1' 'select-pane -D'"
+bind-key -n C-k if-shell "$is_vim" "send-keys C-k"  "if-shell 'expr #{pane_top}' 'select-pane -U'"
+bind-key -n C-l if-shell "$is_vim" "send-keys C-l"  "if-shell 'expr #{window_width} - #{pane_right} - 1' 'select-pane -R'"
 bind-key -n C-\ if-shell "$is_vim" "send-keys C-\\" "select-pane -l"
-bind-key -T copy-mode-vi C-h if -F '#{?pane_at_left,0,1}' 'select-pane -L'
-bind-key -T copy-mode-vi C-j if -F '#{?pane_at_bottom,0,1}' 'select-pane -D'
-bind-key -T copy-mode-vi C-k if -F '#{?pane_at_top,0,1}' 'select-pane -U'
-bind-key -T copy-mode-vi C-l if -F '#{?pane_at_right,0,1}' 'select-pane -R'
+bind-key -T copy-mode-vi C-h if-shell 'expr #{pane_left}' 'select-pane -L'
+bind-key -T copy-mode-vi C-j if-shell 'expr #{window_height} - #{pane_bottom} - 1' 'select-pane -D'
+bind-key -T copy-mode-vi C-k if-shell 'expr #{pane_top}' 'select-pane -U'
+bind-key -T copy-mode-vi C-l if-shell 'expr #{window_width} - #{pane_right} - 1' 'select-pane -R'
 bind-key -T copy-mode-vi C-\ select-pane -l
 ```
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,38 @@ bind -r C-l run "tmux select-pane -R"
 bind -r C-\ run "tmux select-pane -l"
 ```
 
+#### Disable Wrapping
+
+By default, if you try to move past the edge of the screen, tmux/vim will
+"wrap" around to the opposite side. To disable this, you'll need to
+configure both tmux and vim:
+
+
+For vim, you only need to enable this option:
+``` vim
+let g:tmux_navigator_no_wrap = 1
+```
+
+Tmux doesn't have an option, so whatever key bindings you have need to be set
+to conditionally wrap based on position on screen:
+``` tmux
+# Smart pane switching with awareness of Vim splits.
+# See: https://github.com/christoomey/vim-tmux-navigator
+is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
+    | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$'"
+bind-key -n C-h if-shell "$is_vim" "send-keys C-h"  "if -F '#{?pane_at_left,0,1}' 'select-pane -L'"
+bind-key -n C-j if-shell "$is_vim" "send-keys C-j"  "if -F '#{?pane_at_bottom,0,1}' 'select-pane -D'"
+bind-key -n C-k if-shell "$is_vim" "send-keys C-k"  "if -F '#{?pane_at_top,0,1}' 'select-pane -U'"
+bind-key -n C-l if-shell "$is_vim" "send-keys C-l"  "if -F '#{?pane_at_right,0,1}' 'select-pane -R'"
+bind-key -n C-\ if-shell "$is_vim" "send-keys C-\\" "select-pane -l"
+bind-key -T copy-mode-vi C-h if -F '#{?pane_at_left,0,1}' 'select-pane -L'
+bind-key -T copy-mode-vi C-j if -F '#{?pane_at_bottom,0,1}' 'select-pane -D'
+bind-key -T copy-mode-vi C-k if -F '#{?pane_at_top,0,1}' 'select-pane -U'
+bind-key -T copy-mode-vi C-l if -F '#{?pane_at_right,0,1}' 'select-pane -R'
+bind-key -T copy-mode-vi C-\ select-pane -l
+```
+
+
 Troubleshooting
 ---------------
 

--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -116,13 +116,13 @@ function! s:TmuxAwareNavigate(direction)
     " Prevent wrapping, if option is set, by checking if last pane in appropriate direction
     if g:tmux_navigator_no_wrap == 1
       if a:direction == 'h'
-        let args = 'if -F "#{?pane_at_left,0,1}" "' . args . '"'
+        let args = 'if-shell "expr #{pane_left}" "' . args . '"'
       elseif a:direction == 'j'
-        let args = 'if -F "#{?pane_at_bottom,0,1}" "' . args . '"'
+        let args = 'if-shell "expr #{window_height} - #{pane_bottom} - 1 " "' . args . '"'
       elseif a:direction == 'k'
-        let args = 'if -F "#{?pane_at_top,0,1}" "' . args . '"'
+        let args = 'if-shell "expr #{pane_top}" "' . args . '"'
       elseif a:direction == 'l'
-        let args = 'if -F "#{?pane_at_right,0,1}" "' . args . '"'
+        let args = 'if-shell "expr #{window_width} - #{pane_right} - 1" "' . args . '"'
       endif
     endif
     silent call s:TmuxCommand(args)

--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -46,6 +46,10 @@ if !exists("g:tmux_navigator_disable_when_zoomed")
   let g:tmux_navigator_disable_when_zoomed = 0
 endif
 
+if !exists("g:tmux_navigator_no_wrap")
+  let g:tmux_navigator_no_wrap = 0
+endif
+
 function! s:TmuxOrTmateExecutable()
   return (match($TMUX, 'tmate') != -1 ? 'tmate' : 'tmux')
 endfunction
@@ -109,6 +113,18 @@ function! s:TmuxAwareNavigate(direction)
       endtry
     endif
     let args = 'select-pane -t ' . shellescape($TMUX_PANE) . ' -' . tr(a:direction, 'phjkl', 'lLDUR')
+    " Prevent wrapping, if option is set, by checking if last pane in appropriate direction
+    if g:tmux_navigator_no_wrap == 1
+      if a:direction == 'h'
+        let args = 'if -F "#{?pane_at_left,0,1}" "' . args . '"'
+      elseif a:direction == 'j'
+        let args = 'if -F "#{?pane_at_bottom,0,1}" "' . args . '"'
+      elseif a:direction == 'k'
+        let args = 'if -F "#{?pane_at_top,0,1}" "' . args . '"'
+      elseif a:direction == 'l'
+        let args = 'if -F "#{?pane_at_right,0,1}" "' . args . '"'
+      endif
+    endif
     silent call s:TmuxCommand(args)
     if s:NeedsVitalityRedraw()
       redraw!


### PR DESCRIPTION
* Add a vim option (`g:tmux_navigator_no_wrap`) to disable wrapping from within vim
* Add instructions to the Readme for configuring tmux bindings to only select panes when it wouldn't wrap
* Selecting previous tab is unaffected

Addresses #233 