### PR TITLE
Add warning about changes to tmux v3++ configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ bind-key -T copy-mode-vi C-l select-pane -R
 bind-key -T copy-mode-vi C-\ select-pane -l
 ```
 
+In tmux version 3 or higher, you will need to use `'C-\'` in place of `C-\`.
+
 #### TPM
 
 If you'd prefer, you can use the Tmux Plugin Manager ([TPM][]) instead of


### PR DESCRIPTION
Added a small message to README about needing to use `'C-\'` in new versions of tmux instead of `C-\` for tmux configuration. Related to https://github.com/tmux/tmux/issues/1827