### PR TITLE
Don't shell out when detecting vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,11 @@ Add the following to your `~/.tmux.conf` file:
 ``` tmux
 # Smart pane switching with awareness of Vim splits.
 # See: https://github.com/christoomey/vim-tmux-navigator
-is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
-    | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$'"
-bind-key -n 'C-h' if-shell "$is_vim" 'send-keys C-h'  'select-pane -L'
-bind-key -n 'C-j' if-shell "$is_vim" 'send-keys C-j'  'select-pane -D'
-bind-key -n 'C-k' if-shell "$is_vim" 'send-keys C-k'  'select-pane -U'
-bind-key -n 'C-l' if-shell "$is_vim" 'send-keys C-l'  'select-pane -R'
+is_vim="#{m/ri:(^|\/)g?(view|n?vim?)(diff)?$,#{pane_current_command}}"
+bind -n C-h if -F "$is_vim" "send-keys C-h" "select-pane -L"
+bind -n C-j if -F "$is_vim" "send-keys C-j" "select-pane -D"
+bind -n C-k if -F "$is_vim" "send-keys C-k" "select-pane -U"
+bind -n C-l if -F "$is_vim" "send-keys C-l" "select-pane -R"
 tmux_version='$(tmux -V | sed -En "s/^tmux ([0-9]+(.[0-9]+)?).*/\1/p")'
 if-shell -b '[ "$(echo "$tmux_version < 3.0" | bc)" = 1 ]' \
     "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\'  'select-pane -l'"


### PR DESCRIPTION
Even with a totally bare shell, my tmux lags when calling `if-shell`. This PR uses tmux's `if-shell -F` and regex format to test `#{pane_current_command}`, returning true/false without opening a shell at all.

I'm not sure what it loses by using `pane_current_command` instead of `ps` & `pane_tty` so this may be a portability regression, but I wanted to share in case anyone else is experiencing shell-related slowness. Perhaps someone who has more context on why `ps` is preferable can cobble together an implementation that is both portable and shell-free?