### PR TITLE
Fix vim-tmux-navigator version checks

### DIFF
--- a/vim-tmux-navigator.tmux
+++ b/vim-tmux-navigator.tmux
@@ -4,11 +4,11 @@ version_pat='s/^tmux[^0-9]*([.0-9]+).*/\1/p'
 
 is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
     | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$'"
-tmux bind-key -n C-h if-shell "$is_vim" "send-keys C-h"  "select-pane -L"
-tmux bind-key -n C-j if-shell "$is_vim" "send-keys C-j"  "select-pane -D"
-tmux bind-key -n C-k if-shell "$is_vim" "send-keys C-k"  "select-pane -U"
-tmux bind-key -n C-l if-shell "$is_vim" "send-keys C-l"  "select-pane -R"
-tmux_version="$(tmux -V | sed -En "${version_pat}")"
+tmux bind-key -n C-h if-shell "$is_vim" "send-keys C-h" "select-pane -L"
+tmux bind-key -n C-j if-shell "$is_vim" "send-keys C-j" "select-pane -D"
+tmux bind-key -n C-k if-shell "$is_vim" "send-keys C-k" "select-pane -U"
+tmux bind-key -n C-l if-shell "$is_vim" "send-keys C-l" "select-pane -R"
+tmux_version="$(tmux -V | sed -En "$version_pat")"
 tmux setenv -g tmux_version "$tmux_version"
 
 #echo "{'version' : '${tmux_version}', 'sed_pat' : '${version_pat}' }" > ~/.tmux_version.json

--- a/vim-tmux-navigator.tmux
+++ b/vim-tmux-navigator.tmux
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 
+version_pat="s/^tmux ([0-9]+(.[0-9]+)?).*/\1/p"
+
+
 is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
     | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$'"
 tmux bind-key -n C-h if-shell "$is_vim" "send-keys C-h"  "select-pane -L"
 tmux bind-key -n C-j if-shell "$is_vim" "send-keys C-j"  "select-pane -D"
 tmux bind-key -n C-k if-shell "$is_vim" "send-keys C-k"  "select-pane -U"
 tmux bind-key -n C-l if-shell "$is_vim" "send-keys C-l"  "select-pane -R"
-tmux_version='$(tmux -V | sed -En "s/^tmux ([0-9]+(.[0-9]+)?).*/\1/p")'
+tmux_version="$(tmux -V | sed -En '${version_pat}')"
+
 if-shell -b '[ "$(echo "$tmux_version < 3.0" | bc)" = 1 ]' \
     "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\'  'select-pane -l'"
 if-shell -b '[ "$(echo "$tmux_version >= 3.0" | bc)" = 1 ]' \

--- a/vim-tmux-navigator.tmux
+++ b/vim-tmux-navigator.tmux
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-version_pat="s/^tmux ([0-9]+(.[0-9]+)?).*/\1/p"
-
+version_pat='s/^tmux[^0-9]*([.0-9]+).*/\1/p'
 
 is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
     | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$'"
@@ -9,13 +8,14 @@ tmux bind-key -n C-h if-shell "$is_vim" "send-keys C-h"  "select-pane -L"
 tmux bind-key -n C-j if-shell "$is_vim" "send-keys C-j"  "select-pane -D"
 tmux bind-key -n C-k if-shell "$is_vim" "send-keys C-k"  "select-pane -U"
 tmux bind-key -n C-l if-shell "$is_vim" "send-keys C-l"  "select-pane -R"
-tmux_version="$(tmux -V | sed -En '${version_pat}')"
+tmux_version="$(tmux -V | sed -En "${version_pat}")"
+tmux setenv -g tmux_version "$tmux_version"
 
-echo "{'version' : '${tmux_version}', 'sed_pat' : '${version_pat}' }" > ~/.tmux_version.json
+#echo "{'version' : '${tmux_version}', 'sed_pat' : '${version_pat}' }" > ~/.tmux_version.json
 
-if-shell -b '[ "$(echo "$tmux_version < 3.0" | bc)" = 1 ]' \
+tmux if-shell -b '[ "$(echo "$tmux_version < 3.0" | bc)" = 1 ]' \
     "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\'  'select-pane -l'"
-if-shell -b '[ "$(echo "$tmux_version >= 3.0" | bc)" = 1 ]' \
+tmux if-shell -b '[ "$(echo "$tmux_version >= 3.0" | bc)" = 1 ]' \
     "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\\\'  'select-pane -l'"
 
 tmux bind-key -T copy-mode-vi C-h select-pane -L

--- a/vim-tmux-navigator.tmux
+++ b/vim-tmux-navigator.tmux
@@ -11,6 +11,8 @@ tmux bind-key -n C-k if-shell "$is_vim" "send-keys C-k"  "select-pane -U"
 tmux bind-key -n C-l if-shell "$is_vim" "send-keys C-l"  "select-pane -R"
 tmux_version="$(tmux -V | sed -En '${version_pat}')"
 
+echo "{'version' : '${tmux_version}', 'sed_pat' : '${version_pat}' }" > ~/.tmux_version.json
+
 if-shell -b '[ "$(echo "$tmux_version < 3.0" | bc)" = 1 ]' \
     "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\'  'select-pane -l'"
 if-shell -b '[ "$(echo "$tmux_version >= 3.0" | bc)" = 1 ]' \

--- a/vim-tmux-navigator.tmux
+++ b/vim-tmux-navigator.tmux
@@ -14,9 +14,9 @@ tmux setenv -g tmux_version "$tmux_version"
 #echo "{'version' : '${tmux_version}', 'sed_pat' : '${version_pat}' }" > ~/.tmux_version.json
 
 tmux if-shell -b '[ "$(echo "$tmux_version < 3.0" | bc)" = 1 ]' \
-    "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\'  'select-pane -l'"
+  "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\'  'select-pane -l'"
 tmux if-shell -b '[ "$(echo "$tmux_version >= 3.0" | bc)" = 1 ]' \
-    "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\\\'  'select-pane -l'"
+  "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\\\'  'select-pane -l'"
 
 tmux bind-key -T copy-mode-vi C-h select-pane -L
 tmux bind-key -T copy-mode-vi C-j select-pane -D


### PR DESCRIPTION
New pattern tested on "tmux 3.0a", and "tmux next-3.3" . 

Resolved issue with TPM script that  was(incorrectly) directly calling `if-shell`, (as though it was a tmux source script). 

TPM scripts are actually bash scripts, that invoke tmux bindings through the tmux executable, and the correct behaviour is to call `tmux if-shell`. 