### PR TITLE
temporarily set shellcmdflag to -c before calling system

### DIFF
--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -61,7 +61,11 @@ endfunction
 
 function! s:TmuxCommand(args)
   let cmd = s:TmuxOrTmateExecutable() . ' -S ' . s:TmuxSocket() . ' ' . a:args
-  return system(cmd)
+  let l:x=&shellcmdflag
+  let &shellcmdflag='-c'
+  let retval=system(cmd)
+  let &shellcmdflag=l:x
+  return retval
 endfunction
 
 function! s:TmuxNavigatorProcessList()


### PR DESCRIPTION
When i had shellcmdflag set to '-ic' tmux navigation failed.
This patch fixes that.

Regards, Mike