### PR TITLE
Add DownOrRight and UpOrLeft directions.

### DIFF
--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -7,9 +7,51 @@ if exists("g:loaded_tmux_navigator") || &cp || v:version < 700
 endif
 let g:loaded_tmux_navigator = 1
 
-function! s:VimNavigate(direction)
+" Originally by statox from here: https://vi.stackexchange.com/a/16250
+function! HasNeighbor(direction)
+    " Position of the current window
+    let currentPosition = win_screenpos(winnr())
+
+    if a:direction == 'k'
+        " if we are looking for a top neigbour simply test if we are on the first line
+        return currentPosition[0] != 1
+    elseif a:direction == 'h'
+        " if we are looking for a left neigbour simply test if we are on the first column
+        return currentPosition[1] != 1
+    endif
+
+    " Number of windows on the screen
+    let winNr = winnr('$')
+
+    while winNr > 0
+        " Get the position of each window
+        let position = win_screenpos(winNr)
+        let winNr = winNr - 1
+
+        " Test for window on the right
+        if ( a:direction == 'l' && ( currentPosition[1] + winwidth(0) ) < position[1] )
+            return 1
+        " Test for window on the bottom
+        elseif ( a:direction == 'j' && ( currentPosition[0] + winheight(0) ) < position[0] )
+            return 1
+        endif
+    endwhile
+endfunction
+
+function! s:VimNavigate(direction,...)
+  let correct = get(a:, 1, 0)
   try
-    execute 'wincmd ' . a:direction
+    " Check if we have a neighbor in the requested direction
+    let hn = HasNeighbor(a:direction)
+    let correctedDirection = a:direction
+    if correct == 1 && a:direction == 'k' && hn == 0
+      " If we go upwards and there is no neighbor, go left.
+      let correctedDirection = 'h'
+    elseif correct == 1 && a:direction == 'j' && hn == 0
+      " If we go downwards and there is no neighbor, go right.
+      let correctedDirection = 'l'
+    endif
+    execute 'wincmd ' . correctedDirection
   catch
     echohl ErrorMsg | echo 'E11: Invalid in command-line window; <CR> executes, CTRL-C quits: wincmd k' | echohl None
   endtry
@@ -26,7 +68,9 @@ endif
 if empty($TMUX)
   command! TmuxNavigateLeft call s:VimNavigate('h')
   command! TmuxNavigateDown call s:VimNavigate('j')
+  command! TmuxNavigateDownOrRight call s:VimNavigate('j', 1)
   command! TmuxNavigateUp call s:VimNavigate('k')
+  command! TmuxNavigateUpOrLeft call s:VimNavigate('k', 1)
   command! TmuxNavigateRight call s:VimNavigate('l')
   command! TmuxNavigatePrevious call s:VimNavigate('p')
   finish
@@ -34,7 +78,9 @@ endif
 
 command! TmuxNavigateLeft call s:TmuxAwareNavigate('h')
 command! TmuxNavigateDown call s:TmuxAwareNavigate('j')
+command! TmuxNavigateDownOrRight call s:TmuxAwareNavigate('j', 1)
 command! TmuxNavigateUp call s:TmuxAwareNavigate('k')
+command! TmuxNavigateUpOrLeft call s:TmuxAwareNavigate('k', 1)
 command! TmuxNavigateRight call s:TmuxAwareNavigate('l')
 command! TmuxNavigatePrevious call s:TmuxAwareNavigate('p')
 
@@ -90,7 +136,8 @@ function! s:ShouldForwardNavigationBackToTmux(tmux_last_pane, at_tab_page_edge)
   return a:tmux_last_pane || a:at_tab_page_edge
 endfunction
 
-function! s:TmuxAwareNavigate(direction)
+function! s:TmuxAwareNavigate(direction,...)
+  let correct = get(a:, 1, 0)
   let nr = winnr()
   let tmux_last_pane = (a:direction == 'p' && s:tmux_is_last_pane)
   if !tmux_last_pane
@@ -112,7 +159,18 @@ function! s:TmuxAwareNavigate(direction)
       catch /^Vim\%((\a\+)\)\=:E141/ " catches the no file name error
       endtry
     endif
-    let args = 'select-pane -t ' . shellescape($TMUX_PANE) . ' -' . tr(a:direction, 'phjkl', 'lLDUR')
+
+    let hn = HasNeighbor(a:direction)
+    " Change the direction from top to left or from bottom to right as in
+    " VimNavigate above if there is no neighbor in the requested direction.
+    let args = 'select-pane -t ' . shellescape($TMUX_PANE) . ' -'
+    if correct == 1 && a:direction == 'k' && hn == 0
+      let args = args . 'L'
+    elseif correct == 1 && a:direction == 'j' && hn == 0
+      let args = args . 'R'
+    else
+      let args = args . tr(a:direction, 'phjkl', 'lLDUR')
+    endif
     silent call s:TmuxCommand(args)
     if s:NeedsVitalityRedraw()
       redraw!


### PR DESCRIPTION
From other tools I am used to switching windows/panes in a CCW way
where an 'up' translates to a 'left' if there is no window above and
a 'down' becomes a 'right' if there is no window below.

This patch adds two new commands

 `TmuxNavigateDownOrRight`
 `TmuxNavigateUpOrLeft`

that will check check for a neighbor in the requested direction and,
if there is none, change the direction.