### PR TITLE
Add g:tmux_navigator_preserve_zoom option

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,21 @@ To disable navigation when zoomed, add the following to your ~/.vimrc:
 let g:tmux_navigator_disable_when_zoomed = 1
 ```
 
+##### Preserve Zoom
+
+As noted above, navigating from a Vim pane to another tmux pane normally causes
+the window to be unzoomed. Some users may prefer the behavior of tmux's `-Z`
+option to `select-pane`, which keeps the window zoomed if it was zoomed. To
+enable this behavior, the `g:tmux_navigator_preserve_zoom` can be set to `1`:
+
+```vim
+" If the tmux window is zoomed, keep it zoomed when moving from Vim to another pane
+let g:tmux_navigator_preserve_zoom = 1
+```
+
+Naturally, if `g:tmux_navigator_disable_when_zoomed` is enabled, this option
+will have no effect.
+
 #### Tmux
 
 Alter each of the five lines of the tmux configuration listed above to use your

--- a/doc/tmux-navigator.txt
+++ b/doc/tmux-navigator.txt
@@ -24,6 +24,9 @@ CONFIGURATION                             *tmux-navigator-configuration*
 * Disable vim->tmux navigation when the Vim pane is zoomed in tmux
  let g:tmux_navigator_disable_when_zoomed = 1
 
+* If the Vim pane is zoomed, keep zoom on when moving to another tmux pane
+ let g:tmux_navigator_preserve_zoom = 1
+
 * Custom Key Bindings
  let g:tmux_navigator_no_mappings = 1
 

--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -46,6 +46,10 @@ if !exists("g:tmux_navigator_disable_when_zoomed")
   let g:tmux_navigator_disable_when_zoomed = 0
 endif
 
+if !exists("g:tmux_navigator_preserve_zoom")
+  let g:tmux_navigator_preserve_zoom = 0
+endif
+
 function! s:TmuxOrTmateExecutable()
   return (match($TMUX, 'tmate') != -1 ? 'tmate' : 'tmux')
 endfunction
@@ -113,6 +117,9 @@ function! s:TmuxAwareNavigate(direction)
       endtry
     endif
     let args = 'select-pane -t ' . shellescape($TMUX_PANE) . ' -' . tr(a:direction, 'phjkl', 'lLDUR')
+    if g:tmux_navigator_preserve_zoom == 1
+      let l:args .= ' -Z'
+    endif
     silent call s:TmuxCommand(args)
     if s:NeedsVitalityRedraw()
       redraw!


### PR DESCRIPTION
Tmux offers a `-Z` option on the `select-pane` command that preserves the zoom state when navigating between panes. This PR adds an option to enable this behavior in vim-tmux-navigator.

Rationale: I often like to run tmux with two stacked panes, Vim on top and a terminal below. I often keep Vim zoomed and want to briefly pop into the terminal before going back to Vim, all while staying zoomed.