### PR TITLE
Run Neovim default <C-l> before TmuxNavigateRight

### DIFF
--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -17,19 +17,14 @@ endfunction
 
 if !get(g:, 'tmux_navigator_no_mappings', 0)
   if has('nvim')
-    " Neovim should run its default <C-l> binding first
-    nnoremap <silent> <C-l> <Cmd>nohlsearch<Bar>diffupdate<Bar>TmuxNavigateRight<cr>
-    nnoremap <silent> <C-h> <Cmd>nohlsearch<Bar>diffupdate<Bar>TmuxNavigateLeft<cr>
-    nnoremap <silent> <C-j> <Cmd>nohlsearch<Bar>diffupdate<Bar>TmuxNavigateDown<cr>
-    nnoremap <silent> <C-k> <Cmd>nohlsearch<Bar>diffupdate<Bar>TmuxNavigateUp<cr>
-    nnoremap <silent> <C-\> <Cmd>nohlsearch<Bar>diffupdate<Bar>TmuxNavigatePrevious<cr>
+    nnoremap <silent> <c-l> :nohlsearch<Bar>diffupdate<Bar>TmuxNavigateRight<cr>
   else
+    nnoremap <silent> <c-l> :TmuxNavigateRight<cr>
+  endif
     nnoremap <silent> <c-h> :TmuxNavigateLeft<cr>
     nnoremap <silent> <c-j> :TmuxNavigateDown<cr>
     nnoremap <silent> <c-k> :TmuxNavigateUp<cr>
-    nnoremap <silent> <c-l> :TmuxNavigateRight<cr>
     nnoremap <silent> <c-\> :TmuxNavigatePrevious<cr>
-  endif
 endif
 
 if empty($TMUX)

--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -16,11 +16,20 @@ function! s:VimNavigate(direction)
 endfunction
 
 if !get(g:, 'tmux_navigator_no_mappings', 0)
-  nnoremap <silent> <c-h> :TmuxNavigateLeft<cr>
-  nnoremap <silent> <c-j> :TmuxNavigateDown<cr>
-  nnoremap <silent> <c-k> :TmuxNavigateUp<cr>
-  nnoremap <silent> <c-l> :TmuxNavigateRight<cr>
-  nnoremap <silent> <c-\> :TmuxNavigatePrevious<cr>
+  if has('nvim')
+    " Neovim should run its default <C-l> binding first
+    nnoremap <silent> <C-l> <Cmd>nohlsearch<Bar>diffupdate<Bar>TmuxNavigateRight<cr>
+    nnoremap <silent> <C-h> <Cmd>nohlsearch<Bar>diffupdate<Bar>TmuxNavigateLeft<cr>
+    nnoremap <silent> <C-j> <Cmd>nohlsearch<Bar>diffupdate<Bar>TmuxNavigateDown<cr>
+    nnoremap <silent> <C-k> <Cmd>nohlsearch<Bar>diffupdate<Bar>TmuxNavigateUp<cr>
+    nnoremap <silent> <C-\> <Cmd>nohlsearch<Bar>diffupdate<Bar>TmuxNavigatePrevious<cr>
+  else
+    nnoremap <silent> <c-h> :TmuxNavigateLeft<cr>
+    nnoremap <silent> <c-j> :TmuxNavigateDown<cr>
+    nnoremap <silent> <c-k> :TmuxNavigateUp<cr>
+    nnoremap <silent> <c-l> :TmuxNavigateRight<cr>
+    nnoremap <silent> <c-\> :TmuxNavigatePrevious<cr>
+  endif
 endif
 
 if empty($TMUX)


### PR DESCRIPTION
This PR detects when we are running Neovim, and if we are runs the
default <C-l> Neovim mapping first, then calls the `:TmuxNavigateRight`.

The purpose is to respect the default  Neovim <C-l> behaviour. Some may not like this as it is now doing two things: turning off the search highlighting and updating the diff, and then trying to move to the window to the right. Thoughts?