### PR TITLE
send-keys when there is only one pane

### DIFF
--- a/vim-tmux-navigator.tmux
+++ b/vim-tmux-navigator.tmux
@@ -2,21 +2,22 @@
 
 version_pat='s/^tmux[^0-9]*([.0-9]+).*/\1/p'
 
-is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
-    | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$'"
-tmux bind-key -n C-h if-shell "$is_vim" "send-keys C-h" "select-pane -L"
-tmux bind-key -n C-j if-shell "$is_vim" "send-keys C-j" "select-pane -D"
-tmux bind-key -n C-k if-shell "$is_vim" "send-keys C-k" "select-pane -U"
-tmux bind-key -n C-l if-shell "$is_vim" "send-keys C-l" "select-pane -R"
+is_vim_or_one_pane="ps -o state= -o comm= -t '#{pane_tty}' \
+    | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$' \
+    || [ "\$(tmux list-panes | wc -l)" = 1 ]"
+tmux bind-key -n C-h if-shell "$is_vim_or_one_pane" "send-keys C-h" "select-pane -L"
+tmux bind-key -n C-j if-shell "$is_vim_or_one_pane" "send-keys C-j" "select-pane -D"
+tmux bind-key -n C-k if-shell "$is_vim_or_one_pane" "send-keys C-k" "select-pane -U"
+tmux bind-key -n C-l if-shell "$is_vim_or_one_pane" "send-keys C-l" "select-pane -R"
 tmux_version="$(tmux -V | sed -En "$version_pat")"
 tmux setenv -g tmux_version "$tmux_version"
 
 #echo "{'version' : '${tmux_version}', 'sed_pat' : '${version_pat}' }" > ~/.tmux_version.json
 
 tmux if-shell -b '[ "$(echo "$tmux_version < 3.0" | bc)" = 1 ]' \
-  "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\'  'select-pane -l'"
+  "bind-key -n 'C-\\' if-shell \"$is_vim_or_one_pane\" 'send-keys C-\\'  'select-pane -l'"
 tmux if-shell -b '[ "$(echo "$tmux_version >= 3.0" | bc)" = 1 ]' \
-  "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\\\'  'select-pane -l'"
+  "bind-key -n 'C-\\' if-shell \"$is_vim_or_one_pane\" 'send-keys C-\\\\'  'select-pane -l'"
 
 tmux bind-key -T copy-mode-vi C-h select-pane -L
 tmux bind-key -T copy-mode-vi C-j select-pane -D


### PR DESCRIPTION
The idea is that when there's only one pane in the current tmux window, C-{h,j,k,l,\\} must be sent to the shell as is. For instance, without this, C-k (kill all characters after the cursor) and C-l (clear the screen) will not work inside tmux.

I'm a novice in tmux and making things compatible with all shells. If you agree with the idea, please feel free to edit this PR as you see fit.