### PR TITLE
tmux-aware vim split-resizing

### DIFF
--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -79,6 +79,10 @@ if !exists("g:tmux_navigator_preserve_zoom")
   let g:tmux_navigator_preserve_zoom = 0
 endif
 
+if !exists("g:tmux_navigator_resize_step")
+  let g:tmux_navigator_resize_step = 1
+endif
+
 function! s:TmuxOrTmateExecutable()
   return (match($TMUX, 'tmate') != -1 ? 'tmate' : 'tmux')
 endfunction
@@ -214,7 +218,7 @@ endfunction
 
 function! s:TmuxAwareResize(direction)
   if s:ShouldForwardResizeBackToTmux(a:direction)
-    let args = 'resize-pane -t ' . shellescape($TMUX_PANE) . ' -' . tr(a:direction, 'hjkl', 'LDUR')
+    let args = 'resize-pane -t ' . shellescape($TMUX_PANE) . ' -' . tr(a:direction, 'hjkl', 'LDUR') . " " . g:tmux_navigator_resize_step
     silent call s:TmuxCommand(args)
   else
 	let l:layout_before = s:VimLayout()
@@ -230,7 +234,7 @@ function! s:TmuxAwareResize(direction)
 	  let tmux_direction_previous = get({'h':'left', 'j':'up', 'k':'up', 'l':'left'}, tmux_sep_direction)
 	  let tmux_pane_to_resize = (tmux_sep_direction == a:direction) ? shellescape($TMUX_PANE) : "{" . tmux_direction_previous . "-of}"
 	  let tmux_resize_direction = (tmux_sep_direction == a:direction) ? tr(a:direction, 'hjkl', 'LDUR') : tr(a:direction, 'hjkl', 'LUUL')
-      let args = 'resize-pane -t ' . tmux_pane_to_resize . ' -' . tmux_resize_direction
+      let args = 'resize-pane -t ' . tmux_pane_to_resize . ' -' . tmux_resize_direction . " " . g:tmux_navigator_resize_step
       silent call s:TmuxCommand(args)
     endif
   endif

--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -19,7 +19,7 @@ endfunction
 function! s:VimResize(direction)
   let sep_direction = tr(a:direction, 'hjkl', 'ljjl')
   let plus_minus = tr(a:direction, 'hjkl', '-+-+')
-  if winnr() == winnr(directionLimit)
+  if !s:VimHasNeighbour(sep_direction)
     let plus_minus = plus_minus == '+' ? '-' : '+'
   end
   let vertical = tr(a:direction, 'hjkl', '1001')
@@ -155,6 +155,27 @@ function! s:TmuxAwareNavigate(direction)
   else
     let s:tmux_is_last_pane = 0
   endif
+endfunction
+
+" equivalent to 'winnr() == winnr(direction)' for vim < 8.1
+function! s:VimHasNeighbour(direction)
+  let current_position = win_screenpos(winnr())
+  if a:direction == 'k'
+    " Account for potential bufferline
+    return current_position[0] > 2
+  elseif a:direction == 'h'
+    return current_position[1] != 1
+  endif
+  let win_nr = winnr('$')
+  while win_nr > 0
+    let position = win_screenpos(win_nr)
+    let win_nr = win_nr - 1
+    if a:direction == 'l' && (current_position[1] + winwidth(0)) < position[1]
+      return 1
+    elseif a:direction == 'j' && (current_position[0] + winheight(0)) < position[0]
+      return 1
+    endif
+  endwhile
 endfunction
 
 function! s:TmuxAwareResize(direction)

--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -15,12 +15,29 @@ function! s:VimNavigate(direction)
   endtry
 endfunction
 
+" Emulate tmux pane-resizing behavior
+function! s:VimResize(direction)
+  let sep_direction = tr(a:direction, 'hjkl', 'ljjl')
+  let plus_minus = tr(a:direction, 'hjkl', '-+-+')
+  if winnr() == winnr(directionLimit)
+    let plus_minus = plus_minus == '+' ? '-' : '+'
+  end
+  let vertical = tr(a:direction, 'hjkl', '1001')
+  let vimCmd = (vertical ? 'vertical ' : '') . 'resize' . plus_minus . "5"
+  exec vimCmd
+endfunction
+
 if !get(g:, 'tmux_navigator_no_mappings', 0)
   nnoremap <silent> <c-h> :TmuxNavigateLeft<cr>
   nnoremap <silent> <c-j> :TmuxNavigateDown<cr>
   nnoremap <silent> <c-k> :TmuxNavigateUp<cr>
   nnoremap <silent> <c-l> :TmuxNavigateRight<cr>
   nnoremap <silent> <c-\> :TmuxNavigatePrevious<cr>
+
+  nnoremap <silent> h :TmuxResizeLeft<cr>
+  nnoremap <silent> j :TmuxResizeDown<cr>
+  nnoremap <silent> k :TmuxResizeUp<cr>
+  nnoremap <silent> l :TmuxResizeRight<cr>
 endif
 
 if empty($TMUX)
@@ -29,6 +46,11 @@ if empty($TMUX)
   command! TmuxNavigateUp call s:VimNavigate('k')
   command! TmuxNavigateRight call s:VimNavigate('l')
   command! TmuxNavigatePrevious call s:VimNavigate('p')
+
+  command! TmuxResizeLeft call s:VimResize('h')
+  command! TmuxResizeDown call s:VimResize('j')
+  command! TmuxResizeUp call s:VimResize('k')
+  command! TmuxResizeRight call s:VimResize('l')
   finish
 endif
 
@@ -37,6 +59,11 @@ command! TmuxNavigateDown call s:TmuxAwareNavigate('j')
 command! TmuxNavigateUp call s:TmuxAwareNavigate('k')
 command! TmuxNavigateRight call s:TmuxAwareNavigate('l')
 command! TmuxNavigatePrevious call s:TmuxAwareNavigate('p')
+
+command! TmuxResizeLeft call s:TmuxAwareResize('h')
+command! TmuxResizeDown call s:TmuxAwareResize('j')
+command! TmuxResizeUp call s:TmuxAwareResize('k')
+command! TmuxResizeRight call s:TmuxAwareResize('l')
 
 if !exists("g:tmux_navigator_save_on_switch")
   let g:tmux_navigator_save_on_switch = 0
@@ -128,4 +155,8 @@ function! s:TmuxAwareNavigate(direction)
   else
     let s:tmux_is_last_pane = 0
   endif
+endfunction
+
+function! s:TmuxAwareResize(direction)
+  call s:VimResize(a:direction)
 endfunction

--- a/vim-tmux-navigator.tmux
+++ b/vim-tmux-navigator.tmux
@@ -8,6 +8,10 @@ tmux bind-key -n C-h if-shell "$is_vim" "send-keys C-h" "select-pane -L"
 tmux bind-key -n C-j if-shell "$is_vim" "send-keys C-j" "select-pane -D"
 tmux bind-key -n C-k if-shell "$is_vim" "send-keys C-k" "select-pane -U"
 tmux bind-key -n C-l if-shell "$is_vim" "send-keys C-l" "select-pane -R"
+tmux bind-key -n M-h if-shell "$is_vim" 'send-keys M-h' 'resize-pane -L'
+tmux bind-key -n M-j if-shell "$is_vim" 'send-keys M-h' 'resize-pane -D'
+tmux bind-key -n M-k if-shell "$is_vim" 'send-keys M-h' 'resize-pane -U'
+tmux bind-key -n M-l if-shell "$is_vim" 'send-keys M-h' 'resize-pane -R'
 tmux_version="$(tmux -V | sed -En "$version_pat")"
 tmux setenv -g tmux_version "$tmux_version"
 


### PR DESCRIPTION
Hello everyone !

First of all, thanks a lot for the work you put on the plugin, I enjoy using it very much, and it is making my life quite easier !

I wanted to potentially improve on the plugin by also allowing to resize easily between vim splits and tmux panes.
The usual use-case would be this: When I am looking at something in vim, there are a lot of time where I want to make a split wider to get a bigger view. The problem is, whenever the split covers the full tmux pane, if I want it to take more space, I am usually stuck as far as vim commands go. What I usually have to do then is switch to a different tmux pane, do the resizing in tmux, and then go back, which I find quite frustrating every time. Plus, I always found the split-resizing in vim to be quite painful in general.

So if we could get a way to resize both tmux panes and vim split as if they were the same thing, that would kill 2 birds with one stone. And I think I have achieved that.

I have to say, I am absolutely no specialist neither in vimscript nor in developing vim plugins, so there are probably some obvious things that are not optimized, or that I forgot to add in, especially when it comes to other tmux/tmate/vim versions. These changes work without any problems (at least for the basic use that I have of vim and tmux) for vim v8.0 and tmux v2.6. 

Anyway, if you have any feedback on that, no matter whether or not you want to accept it, I would love to hear from you.

The problem space turned out to be surprisingly tricky, so it might not be 100% apparent what all the code does at first sight I admit. So if you have any question don't hesitate to ping me, I'll be very happy to answer them.

One thing that I think helped me a lot was to think about the tmux resizing behavior as "moving a separator/splitter" (instead of "growing the cell by X amount", like in vim), where the separator to be moved is always the one on the left/at the bottom, unless your at the left/bottom edge of the window, in which case it will be the separator directly on the right/top, respectively.
Long story short, a lot of what I am doing here is finding where the tmux separator is supposed to be compared to the current vim split.

So that's it, I hope you like it and find it somewhat interesting, if not useful.
Again, thanks a lot for your time and effort.
Bye !