### PR TITLE
Add option to disable wrapping when switch panes

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,33 @@ With this enabled you can use `<prefix> C-l` to clear the screen.
 
 Thanks to [Brian Hogan][] for the tip on how to re-map the clear screen binding.
 
+#### Disable Wrapping
+
+By default, if you tru to move past the edge of the screen, tmux/vim will
+"wrap" around to the opposite side. To disable this, you'll need to
+configure both tmux and vim:
+
+For vim, you only need to enable this option:
+```vim
+let  g:tmux_navigator_no_wrap = 1
+```
+
+Tmux doesn't haave an option, so whatever key bindings you have need to be set
+to conditionally wrap based on position on screen:
+```tmux
+is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
+    | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$'"
+bind-key -n 'C-h' if-shell "$is_vim" { send-keys C-h } { if-shell -F '#{pane_at_left}'   {} { select-pane -L } }
+bind-key -n 'C-j' if-shell "$is_vim" { send-keys C-j } { if-shell -F '#{pane_at_bottom}' {} { select-pane -D } }
+bind-key -n 'C-k' if-shell "$is_vim" { send-keys C-k } { if-shell -F '#{pane_at_top}'    {} { select-pane -U } }
+bind-key -n 'C-l' if-shell "$is_vim" { send-keys C-l } { if-shell -F '#{pane_at_right}'  {} { select-pane -R } }
+
+bind-key -T copy-mode-vi 'C-h' if-shell -F '#{pane_at_left}'   {} { select-pane -L }
+bind-key -T copy-mode-vi 'C-j' if-shell -F '#{pane_at_bottom}' {} { select-pane -D }
+bind-key -T copy-mode-vi 'C-k' if-shell -F '#{pane_at_top}'    {} { select-pane -U }
+bind-key -T copy-mode-vi 'C-l' if-shell -F '#{pane_at_right}'  {} { select-pane -R }
+```
+
 #### Nesting
 If you like to nest your tmux sessions, this plugin is not going to work
 properly. It probably never will, as it would require detecting when Tmux would

--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -50,6 +50,12 @@ if !exists("g:tmux_navigator_preserve_zoom")
   let g:tmux_navigator_preserve_zoom = 0
 endif
 
+if !exists("g:tmux_navigator_no_wrap")
+  let g:tmux_navigator_no_wrap = 0
+endif
+
+let s:pane_position_from_direction = {'h': 'left', 'j': 'bottom', 'k': 'top', 'l': 'right'}
+
 function! s:TmuxOrTmateExecutable()
   return (match($TMUX, 'tmate') != -1 ? 'tmate' : 'tmux')
 endfunction
@@ -119,6 +125,9 @@ function! s:TmuxAwareNavigate(direction)
     let args = 'select-pane -t ' . shellescape($TMUX_PANE) . ' -' . tr(a:direction, 'phjkl', 'lLDUR')
     if g:tmux_navigator_preserve_zoom == 1
       let l:args .= ' -Z'
+    endif
+    if g:tmux_navigator_no_wrap == 1
+      let args = 'if -F "#{pane_at_' . s:pane_position_from_direction[a:direction] . '}" "" "' . args . '"'
     endif
     silent call s:TmuxCommand(args)
     if s:NeedsVitalityRedraw()


### PR DESCRIPTION
* Add g:tmux_navigator_no_wrap option to disable wrap around
* Add instructions on how to configure this feature

Based on patch by @heewa

Fixes #233