### PR TITLE
Optimise `vi` detection logic and use internal macros and commands as much as possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Add the following to your `~/.tmux.conf` file:
 # Smart pane switching with awareness of Vim splits.
 # See: https://github.com/christoomey/vim-tmux-navigator
 
-# pseudo substring match by substituting the current command from the current commmand string
+# pseudo substring match by substituting "g?(view|n?vim?x?)(diff)?$" from the current commmand string
 bind-key -n C-k if-shell "[ '#{pane_current_command}' != '#{s/g?(view|n?vim?x?)(diff)?$//:#{pane_current_command}}' ]" "send-keys C-k" "select-pane -U"
 bind-key -n C-j if-shell "[ '#{pane_current_command}' != '#{s/g?(view|n?vim?x?)(diff)?$//:#{pane_current_command}}' ]" "send-keys C-j" "select-pane -D"
 bind-key -n C-h if-shell "[ '#{pane_current_command}' != '#{s/g?(view|n?vim?x?)(diff)?$//:#{pane_current_command}}' ]" "send-keys C-h" "select-pane -L"

--- a/README.md
+++ b/README.md
@@ -65,17 +65,21 @@ Add the following to your `~/.tmux.conf` file:
 ``` tmux
 # Smart pane switching with awareness of Vim splits.
 # See: https://github.com/christoomey/vim-tmux-navigator
-is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
-    | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$'"
-bind-key -n 'C-h' if-shell "$is_vim" 'send-keys C-h'  'select-pane -L'
-bind-key -n 'C-j' if-shell "$is_vim" 'send-keys C-j'  'select-pane -D'
-bind-key -n 'C-k' if-shell "$is_vim" 'send-keys C-k'  'select-pane -U'
-bind-key -n 'C-l' if-shell "$is_vim" 'send-keys C-l'  'select-pane -R'
-tmux_version='$(tmux -V | sed -En "s/^tmux ([0-9]+(.[0-9]+)?).*/\1/p")'
-if-shell -b '[ "$(echo "$tmux_version < 3.0" | bc)" = 1 ]' \
-    "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\'  'select-pane -l'"
-if-shell -b '[ "$(echo "$tmux_version >= 3.0" | bc)" = 1 ]' \
-    "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\\\'  'select-pane -l'"
+
+# pseudo substring match by substituting the current command from the current commmand string
+bind-key -n C-k if-shell "[ '#{pane_current_command}' != '#{s/g?(view|n?vim?x?)(diff)?$//:#{pane_current_command}}' ]" "send-keys C-k" "select-pane -U"
+bind-key -n C-j if-shell "[ '#{pane_current_command}' != '#{s/g?(view|n?vim?x?)(diff)?$//:#{pane_current_command}}' ]" "send-keys C-j" "select-pane -D"
+bind-key -n C-h if-shell "[ '#{pane_current_command}' != '#{s/g?(view|n?vim?x?)(diff)?$//:#{pane_current_command}}' ]" "send-keys C-h" "select-pane -L"
+bind-key -n C-l if-shell "[ '#{pane_current_command}' != '#{s/g?(view|n?vim?x?)(diff)?$//:#{pane_current_command}}' ]" "send-keys C-l" "select-pane -R"
+# bring back clear screen (PREFIX + CTRL + l)
+bind-key C-l send-keys "C-l"
+
+# if "${tmux_version}" is greater or equal "3.0", then "send-keys C-\\\\", else "send-keys C-\\"
+# https://unix.stackexchange.com/a/285928
+tmux_version="#{version}"
+if-shell -b "[ #(printf '%s\n' '3.0' '${tmux_version}' | sort --version-sort | head --lines='1') ]" \
+    "bind-key -n C-\\ 'send-keys C-\\\\' 'select-pane -l'" \
+    "bind-key -n C-\\ 'send-keys C-\\'  'select-pane -l'"
 
 bind-key -T copy-mode-vi 'C-h' select-pane -L
 bind-key -T copy-mode-vi 'C-j' select-pane -D

--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -2,6 +2,22 @@
 " no more windows in that direction, forwards the operation to tmux.
 " Additionally, <C-\> toggles between last active vim splits/tmux panes.
 
+" i am not sure about this one, but the below commented snipped is sufficient.
+" vim-tmux-navigator
+" function! TmuxMove(direction)
+"     let wnr = winnr()
+"     silent! execute 'wincmd ' . a:direction
+"     " if the winnr is still the same after we moved, it is the last pane.
+"     if wnr == winnr()
+"         call system('tmux select-pane -' . tr(a:direction, 'phjkl', 'lLDUR'))
+"     end
+" endfunction
+" 
+" nnoremap <silent> <c-h> :call TmuxMove('h')<cr>
+" nnoremap <silent> <c-j> :call TmuxMove('j')<cr>
+" nnoremap <silent> <c-k> :call TmuxMove('k')<cr>
+" nnoremap <silent> <c-l> :call TmuxMove('l')<cr>
+
 if exists("g:loaded_tmux_navigator") || &cp || v:version < 700
   finish
 endif

--- a/vim-tmux-navigator.tmux
+++ b/vim-tmux-navigator.tmux
@@ -8,11 +8,11 @@ tmux bind-key -n C-l if-shell "[ '#{pane_current_command}' != '#{s/g?(view|n?vim
 # bring back clear screen (PREFIX + CTRL + l)
 tmux bind-key C-l send-keys "C-l"
 
-# if "${tmux_version}" is greater or equal "3.0", then "send-keys C-\\\\", else "send-keys C-\\"
-# https://unix.stackexchange.com/a/285928
 tmux_version=$(tmux display-message -p "#{version}")
 tmux setenv -g tmux_version "${tmux_version}"
 
+# if "${tmux_version}" is greater or equal "3.0", then "send-keys C-\\\\", else "send-keys C-\\"
+# https://unix.stackexchange.com/a/285928
 tmux if-shell -b "[ #(printf '%s\n' '3.0' '${tmux_version}' | sort --version-sort | head --lines='1') ]" \
     "bind-key -n C-\\ 'send-keys C-\\\\' 'select-pane -l'" \
     "bind-key -n C-\\ 'send-keys C-\\'  'select-pane -l'"

--- a/vim-tmux-navigator.tmux
+++ b/vim-tmux-navigator.tmux
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# pseudo substring match by substituting the current command from the current commmand string
+# pseudo substring match by substituting "g?(view|n?vim?x?)(diff)?$" from the current commmand string
 tmux bind-key -n C-k if-shell "[ '#{pane_current_command}' != '#{s/g?(view|n?vim?x?)(diff)?$//:#{pane_current_command}}' ]" "send-keys C-k" "select-pane -U"
 tmux bind-key -n C-j if-shell "[ '#{pane_current_command}' != '#{s/g?(view|n?vim?x?)(diff)?$//:#{pane_current_command}}' ]" "send-keys C-j" "select-pane -D"
 tmux bind-key -n C-h if-shell "[ '#{pane_current_command}' != '#{s/g?(view|n?vim?x?)(diff)?$//:#{pane_current_command}}' ]" "send-keys C-h" "select-pane -L"


### PR DESCRIPTION
Resolves #300 and should also resolve #295.

This pull-request uses:

* The internal macro`#{version}` to determine the `current tmux version`<sup>1</sup>
* `Else clauses` for `if-shell`<sup>2</sup>
* `display-message -p` to output the version in `bash`<sup>3</sup>
* `printf`, `sort` and `head` to check, if the `current tmux version` is higher, than `3.0`. The last two commands come from the package `coreutils`, which has more portability, than `bc`.
* The `vi` detection logic uses a `pseudo substring match` by substituting `g?(view|n?vim?x?)(diff)?$` from `#{pane_current_command}`.<sup>4</sup>

Also everything is refactored to use internal macros and commands as much as possible to cause less load and invoking less subshells.

I was not sure about the `vim`-part, but left a comment there with a snippet, which could be used.

I adapted everything by logic and tested only certain parts of the plugin.

-Ramon

<sup>1</sup>
See `CHANGES FROM 2.3 TO 2.4, 20 April 2017`
https://github.com/tmux/tmux/blob/master/CHANGES

<sup>2</sup>
See `CHANGES FROM 1.5 TO 1.6, 23 January 2012`
https://github.com/tmux/tmux/blob/master/CHANGES

<sup>3</sup>
See `CHANGES FROM 1.1 TO 1.2, 10 March 2010`
https://github.com/tmux/tmux/blob/master/CHANGES

<sup>4</sup>
See `CHANGES FROM 2.1 TO 2.2, 10 April 2016`
https://github.com/tmux/tmux/blob/master/CHANGES