### PR TITLE
Map the vim bindings in more modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,16 +115,16 @@ Add the following to your `~/.vimrc` to define your custom maps:
 ``` vim
 let g:tmux_navigator_no_mappings = 1
 
-nnoremap <silent> {Left-Mapping} :TmuxNavigateLeft<cr>
-nnoremap <silent> {Down-Mapping} :TmuxNavigateDown<cr>
-nnoremap <silent> {Up-Mapping} :TmuxNavigateUp<cr>
-nnoremap <silent> {Right-Mapping} :TmuxNavigateRight<cr>
-nnoremap <silent> {Previous-Mapping} :TmuxNavigatePrevious<cr>
+noremap <silent> {Left-Mapping} :<C-U>TmuxNavigateLeft<cr>
+noremap <silent> {Down-Mapping} :<C-U>TmuxNavigateDown<cr>
+noremap <silent> {Up-Mapping} :<C-U>TmuxNavigateUp<cr>
+noremap <silent> {Right-Mapping} :<C-U>TmuxNavigateRight<cr>
+noremap <silent> {Previous-Mapping} :<C-U>TmuxNavigatePrevious<cr>
 ```
 
 *Note* Each instance of `{Left-Mapping}` or `{Down-Mapping}` must be replaced
 in the above code with the desired mapping. Ie, the mapping for `<ctrl-h>` =>
-Left would be created with `nnoremap <silent> <c-h> :TmuxNavigateLeft<cr>`.
+Left would be created with `noremap <silent> <c-h> :<C-U>TmuxNavigateLeft<cr>`.
 
 ##### Autosave on leave
 
@@ -263,7 +263,7 @@ Troubleshooting
 
 This is likely due to conflicting key mappings in your `~/.vimrc`. You can use
 the following search pattern to find conflicting mappings
-`\vn(nore)?map\s+\<c-[hjkl]\>`. Any matching lines should be deleted or
+`\v(nore)?map\s+\<c-[hjkl]\>`. Any matching lines should be deleted or
 altered to avoid conflicting with the mappings from the plugin.
 
 Another option is that the pattern matching included in the `.tmux.conf` is

--- a/doc/tmux-navigator.txt
+++ b/doc/tmux-navigator.txt
@@ -30,10 +30,10 @@ CONFIGURATION                             *tmux-navigator-configuration*
 * Custom Key Bindings
  let g:tmux_navigator_no_mappings = 1
 
- nnoremap <silent> {Left-mapping} :TmuxNavigateLeft<cr>
- nnoremap <silent> {Down-Mapping} :TmuxNavigateDown<cr>
- nnoremap <silent> {Up-Mapping} :TmuxNavigateUp<cr>
- nnoremap <silent> {Right-Mapping} :TmuxNavigateRight<cr>
- nnoremap <silent> {Previous-Mapping} :TmuxNavigatePrevious<cr>
+ noremap <silent> {Left-mapping} :<C-U>TmuxNavigateLeft<cr>
+ noremap <silent> {Down-Mapping} :<C-U>TmuxNavigateDown<cr>
+ noremap <silent> {Up-Mapping} :<C-U>TmuxNavigateUp<cr>
+ noremap <silent> {Right-Mapping} :<C-U>TmuxNavigateRight<cr>
+ noremap <silent> {Previous-Mapping} :<C-U><C-U>TmuxNavigatePrevious<cr>
 
  vim:tw=78:ts=8:ft=help:norl:

--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -16,11 +16,11 @@ function! s:VimNavigate(direction)
 endfunction
 
 if !get(g:, 'tmux_navigator_no_mappings', 0)
-  nnoremap <silent> <c-h> :TmuxNavigateLeft<cr>
-  nnoremap <silent> <c-j> :TmuxNavigateDown<cr>
-  nnoremap <silent> <c-k> :TmuxNavigateUp<cr>
-  nnoremap <silent> <c-l> :TmuxNavigateRight<cr>
-  nnoremap <silent> <c-\> :TmuxNavigatePrevious<cr>
+  noremap <silent> <c-h> :<C-U>TmuxNavigateLeft<cr>
+  noremap <silent> <c-j> :<C-U>TmuxNavigateDown<cr>
+  noremap <silent> <c-k> :<C-U>TmuxNavigateUp<cr>
+  noremap <silent> <c-l> :<C-U>TmuxNavigateRight<cr>
+  noremap <silent> <c-\> :<C-U>TmuxNavigatePrevious<cr>
 endif
 
 if empty($TMUX)


### PR DESCRIPTION
Use `(nore)map` to map the functions in visual, select and operator-pending mode instead of only in normal mode.

Use `<C-U>` ([:h c_CTRL-U](https://vimhelp.org/cmdline.txt.html#c_CTRL-U)) to delete the automatically inserted range when pressing `:` in visual mode, as the functions do not support a range.

Update all references in the README and help page.