### PR TITLE
Add information on SIGQUIT key binding options

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,22 @@ With this enabled you can use `<prefix> C-l` to clear the screen.
 
 Thanks to [Brian Hogan][] for the tip on how to re-map the clear screen binding.
 
+#### Restoring SIGQUIT (C-\\)
+
+The default key bindings also include `<Ctrl-\>` which is the default method of
+sending SIGQUIT to a foreground process. Similar to "Clear Screen" above, a key
+binding can be created to replicate SIGQUIT in the prefix table.
+
+``` tmux
+bind C-\\ send-keys 'C-\'
+```
+
+Alternatively, you can exclude the previous pane key binding from your `~/.tmux.conf`. If using TPM, the following line can be used to unbind the previous pane binding set by the plugin.
+
+``` tmux
+unbind -n C-\\
+```
+
 #### Disable Wrapping
 
 By default, if you tru to move past the edge of the screen, tmux/vim will


### PR DESCRIPTION
I occasionally use `Ctrl-\` to send `SIGQUIT` to a process running in the foreground, and it took me a few minutes to trace my issue to this plugin. This PR adds some info to the `README.md` on how to rebind SIGQUIT to the prefix table or unbind it for tmux navigation. I've placed it directly after similar guidance on the clear screen key binding.