### PR TITLE
Adapt is_vim so that it works with .vim-wrapped on NixOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Add the following to your `~/.tmux.conf` file:
 # Smart pane switching with awareness of Vim splits.
 # See: https://github.com/christoomey/vim-tmux-navigator
 is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
-    | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|l?n?vim?x?|fzf)(diff)?$'"
+    | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?\.?(view|l?n?vim?x?|fzf)(diff)?(-wrapped)?$'"
 bind-key -n 'C-h' if-shell "$is_vim" 'send-keys C-h'  'select-pane -L'
 bind-key -n 'C-j' if-shell "$is_vim" 'send-keys C-j'  'select-pane -D'
 bind-key -n 'C-k' if-shell "$is_vim" 'send-keys C-k'  'select-pane -U'

--- a/pattern-check
+++ b/pattern-check
@@ -11,8 +11,9 @@ GREEN=$(tput setaf 2)
 YELLOW=$(tput setaf 3)
 NORMAL=$(tput sgr0)
 
-vim_pattern='(^|\/)g?(view|l?n?vim?x?|fzf)(diff)?$'
-match_tests=(vim Vim VIM vimdiff lvim /usr/local/bin/vim vi gvim view gview nvim vimx fzf)
+
+vim_pattern='(\\S+\\/)?g?\.?(view|l?n?vim?x?|fzf)(diff)?(-wrapped)?$'
+match_tests=(vim Vim VIM vimdiff lvim /usr/local/bin/vim vi gvim view gview nvim vimx fzf .vim-wrapped .nvim-wrapped)
 no_match_tests=( /Users/christoomey/.vim/thing /usr/local/bin/start-vim )
 
 display_matches() {

--- a/vim-tmux-navigator.tmux
+++ b/vim-tmux-navigator.tmux
@@ -26,7 +26,7 @@ bind_key_vim() {
   key="$1"
   tmux_cmd="$2"
   is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
-      | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|l?n?vim?x?|fzf)(diff)?$'"
+      | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?\.?(view|l?n?vim?x?|fzf)(diff)?(-wrapped)?$'"
   # sending C-/ according to https://github.com/tmux/tmux/issues/1827
   tmux bind-key -n "$key" if-shell "$is_vim" "send-keys '$key'" "$tmux_cmd"
   # tmux < 3.0 cannot parse "$tmux_cmd" as one argument, thus copying as multiple arguments


### PR DESCRIPTION
vim on NixOS presents itself as `.vim-wrapped` which was not covered in the regexp of `is_vim`.

Fixes #264.

Given the increasing adoption of NixOS as compared to in 2017, would you please reconsider your statement at https://github.com/christoomey/vim-tmux-navigator/pull/171#issuecomment-315064855 and be so kind as to accept this merge request?