### PR TITLE
TPM Plugin configure key mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ bind-key -T copy-mode-vi 'C-\' select-pane -l
 
 #### TPM
 
-If you'd prefer, you can use the Tmux Plugin Manager ([TPM][]) instead of
+If you prefer, you can use the Tmux Plugin Manager ([TPM][]) instead of
 copying the snippet.
 When using TPM, add the following lines to your ~/.tmux.conf:
 
@@ -119,7 +119,8 @@ When using TPM, add the following lines to your ~/.tmux.conf:
 set -g @plugin 'christoomey/vim-tmux-navigator'
 ```
 
-To set a different key-binding, use the plugin configuration settings (remember to update your vim config accordingly).
+To set a different key-binding, use the plugin configuration settings
+(remember to update your vim config accordingly).
 Multiple key bindings are possible, use a space to separate.
 
 ``` tmux

--- a/README.md
+++ b/README.md
@@ -117,6 +117,21 @@ When using TPM, add the following lines to your ~/.tmux.conf:
 
 ``` tmux
 set -g @plugin 'christoomey/vim-tmux-navigator'
+```
+
+To set a different key-binding, use the plugin configuration settings (remember to update your vim config accordingly).
+Multiple key bindings are possible, use a space to separate.
+
+``` tmux
+set -g @vim_navigator_mapping_left "C-Left C-h"  # use C-h and C-Left
+set -g @vim_navigator_mapping_right "C-Right C-l"
+set -g @vim_navigator_mapping_up "C-k"
+set -g @vim_navigator_mapping_down "C-j"
+set -g @vim_navigator_mapping_prev ""  # removes the C-\ binding
+```
+Don't forget to run tpm:
+
+``` tmux
 run '~/.tmux/plugins/tpm/tpm'
 ```
 

--- a/vim-tmux-navigator.tmux
+++ b/vim-tmux-navigator.tmux
@@ -17,6 +17,15 @@ get_tmux_option() {
   fi
 }
 
+bind_key_vim() {
+  local key tmux_cmd is_vim
+  key="$1"
+  tmux_cmd="$2"
+  is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
+      | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|l?n?vim?x?|fzf)(diff)?$'"
+  tmux bind-key -n "$key" if-shell "$is_vim" "send-keys $key" "$tmux_cmd"
+  tmux bind-key -T copy-mode-vi "$key" "$tmux_cmd"
+}
 
 version_pat='s/^tmux[^0-9]*([.0-9]+).*/\1/p'
 move_left="$(get_tmux_option "@vim_navigator_mapping_left" "C-h")"
@@ -24,25 +33,21 @@ move_right="$(get_tmux_option "@vim_navigator_mapping_right" "C-l")"
 move_up="$(get_tmux_option "@vim_navigator_mapping_up" "C-k")"
 move_down="$(get_tmux_option "@vim_navigator_mapping_down" "C-j")"
 
-is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
-    | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|l?n?vim?x?|fzf)(diff)?$'"
-tmux bind-key -n "$move_left"  if-shell "$is_vim" "send-keys $move_left"  "select-pane -L"
-tmux bind-key -n "$move_down"  if-shell "$is_vim" "send-keys $move_down"  "select-pane -D"
-tmux bind-key -n "$move_up"    if-shell "$is_vim" "send-keys $move_up"    "select-pane -U"
-tmux bind-key -n "$move_right" if-shell "$is_vim" "send-keys $move_right" "select-pane -R"
+for k in $(echo "$move_left");  do bind_key_vim "$k" "select-pane -L"; done
+for k in $(echo "$move_down");  do bind_key_vim "$k" "select-pane -D"; done
+for k in $(echo "$move_up");    do bind_key_vim "$k" "select-pane -U"; done
+for k in $(echo "$move_right"); do bind_key_vim "$k" "select-pane -R"; done
+
 tmux_version="$(tmux -V | sed -En "$version_pat")"
 tmux setenv -g tmux_version "$tmux_version"
 
 #echo "{'version' : '${tmux_version}', 'sed_pat' : '${version_pat}' }" > ~/.tmux_version.json
 
-tmux if-shell -b '[ "$(echo "$tmux_version < 3.0" | bc)" = 1 ]' \
-  "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\'  'select-pane -l'"
-tmux if-shell -b '[ "$(echo "$tmux_version >= 3.0" | bc)" = 1 ]' \
-  "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\\\'  'select-pane -l'"
-
-tmux bind-key -T copy-mode-vi "$move_left" select-pane -L
-tmux bind-key -T copy-mode-vi "$move_down" select-pane -D
-tmux bind-key -T copy-mode-vi "$move_up" select-pane -U
-tmux bind-key -T copy-mode-vi "$move_right" select-pane -R
-tmux bind-key -T copy-mode-vi C-\\ select-pane -l
+#is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
+#    | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|l?n?vim?x?|fzf)(diff)?$'"
+#tmux if-shell -b '[ "$(echo "$tmux_version < 3.0" | bc)" = 1 ]' \
+#  "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\'  'select-pane -l'"
+#tmux if-shell -b '[ "$(echo "$tmux_version >= 3.0" | bc)" = 1 ]' \
+#  "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\\\'  'select-pane -l'"
+#tmux bind-key -T copy-mode-vi C-\\ select-pane -l
 

--- a/vim-tmux-navigator.tmux
+++ b/vim-tmux-navigator.tmux
@@ -25,7 +25,8 @@ bind_key_vim() {
       | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|l?n?vim?x?|fzf)(diff)?$'"
   # sending C-/ according to https://github.com/tmux/tmux/issues/1827
   tmux bind-key -n "$key" if-shell "$is_vim" "send-keys '$key'" "$tmux_cmd"
-  tmux bind-key -T copy-mode-vi "$key" "$tmux_cmd"
+  # tmux < 3.0 cannot parse "$tmux_cmd" as one argument, thus copying as multiple arguments
+  tmux bind-key -T copy-mode-vi "$key" $tmux_cmd
 }
 
 move_left="$(get_tmux_option "@vim_navigator_mapping_left" 'C-h')"

--- a/vim-tmux-navigator.tmux
+++ b/vim-tmux-navigator.tmux
@@ -1,13 +1,35 @@
 #!/usr/bin/env bash
 
+get_tmux_option() {
+  local option value default
+  option="$1"
+  default="$2"
+  value=$(tmux show-option -gqv "$option")
+
+  if [ -n "$value" ]; then
+    if [ "$value" = "null" ]; then
+      echo ""
+    else
+      echo "$value"
+    fi
+  else
+    echo "$default"
+  fi
+}
+
+
 version_pat='s/^tmux[^0-9]*([.0-9]+).*/\1/p'
+move_left="$(get_tmux_option "@vim_navigator_mapping_left" "C-h")"
+move_right="$(get_tmux_option "@vim_navigator_mapping_right" "C-l")"
+move_up="$(get_tmux_option "@vim_navigator_mapping_up" "C-k")"
+move_down="$(get_tmux_option "@vim_navigator_mapping_down" "C-j")"
 
 is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
     | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|l?n?vim?x?|fzf)(diff)?$'"
-tmux bind-key -n C-h if-shell "$is_vim" "send-keys C-h" "select-pane -L"
-tmux bind-key -n C-j if-shell "$is_vim" "send-keys C-j" "select-pane -D"
-tmux bind-key -n C-k if-shell "$is_vim" "send-keys C-k" "select-pane -U"
-tmux bind-key -n C-l if-shell "$is_vim" "send-keys C-l" "select-pane -R"
+tmux bind-key -n "$move_left"  if-shell "$is_vim" "send-keys $move_left"  "select-pane -L"
+tmux bind-key -n "$move_down"  if-shell "$is_vim" "send-keys $move_down"  "select-pane -D"
+tmux bind-key -n "$move_up"    if-shell "$is_vim" "send-keys $move_up"    "select-pane -U"
+tmux bind-key -n "$move_right" if-shell "$is_vim" "send-keys $move_right" "select-pane -R"
 tmux_version="$(tmux -V | sed -En "$version_pat")"
 tmux setenv -g tmux_version "$tmux_version"
 
@@ -18,8 +40,9 @@ tmux if-shell -b '[ "$(echo "$tmux_version < 3.0" | bc)" = 1 ]' \
 tmux if-shell -b '[ "$(echo "$tmux_version >= 3.0" | bc)" = 1 ]' \
   "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\\\'  'select-pane -l'"
 
-tmux bind-key -T copy-mode-vi C-h select-pane -L
-tmux bind-key -T copy-mode-vi C-j select-pane -D
-tmux bind-key -T copy-mode-vi C-k select-pane -U
-tmux bind-key -T copy-mode-vi C-l select-pane -R
+tmux bind-key -T copy-mode-vi "$move_left" select-pane -L
+tmux bind-key -T copy-mode-vi "$move_down" select-pane -D
+tmux bind-key -T copy-mode-vi "$move_up" select-pane -U
+tmux bind-key -T copy-mode-vi "$move_right" select-pane -R
 tmux bind-key -T copy-mode-vi C-\\ select-pane -l
+

--- a/vim-tmux-navigator.tmux
+++ b/vim-tmux-navigator.tmux
@@ -23,31 +23,23 @@ bind_key_vim() {
   tmux_cmd="$2"
   is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
       | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|l?n?vim?x?|fzf)(diff)?$'"
-  tmux bind-key -n "$key" if-shell "$is_vim" "send-keys $key" "$tmux_cmd"
+  # sending C-/ according to https://github.com/tmux/tmux/issues/1827
+  tmux bind-key -n "$key" if-shell "$is_vim" "send-keys '$key'" "$tmux_cmd"
   tmux bind-key -T copy-mode-vi "$key" "$tmux_cmd"
 }
 
-version_pat='s/^tmux[^0-9]*([.0-9]+).*/\1/p'
-move_left="$(get_tmux_option "@vim_navigator_mapping_left" "C-h")"
-move_right="$(get_tmux_option "@vim_navigator_mapping_right" "C-l")"
-move_up="$(get_tmux_option "@vim_navigator_mapping_up" "C-k")"
-move_down="$(get_tmux_option "@vim_navigator_mapping_down" "C-j")"
+move_left="$(get_tmux_option "@vim_navigator_mapping_left" 'C-h')"
+move_right="$(get_tmux_option "@vim_navigator_mapping_right" 'C-l')"
+move_up="$(get_tmux_option "@vim_navigator_mapping_up" 'C-k')"
+move_down="$(get_tmux_option "@vim_navigator_mapping_down" 'C-j')"
+move_prev="$(get_tmux_option "@vim_navigator_mapping_prev" 'C-\')"
 
 for k in $(echo "$move_left");  do bind_key_vim "$k" "select-pane -L"; done
 for k in $(echo "$move_down");  do bind_key_vim "$k" "select-pane -D"; done
 for k in $(echo "$move_up");    do bind_key_vim "$k" "select-pane -U"; done
 for k in $(echo "$move_right"); do bind_key_vim "$k" "select-pane -R"; done
+for k in $(echo "$move_prev");  do bind_key_vim "$k" "select-pane -l"; done
 
-tmux_version="$(tmux -V | sed -En "$version_pat")"
-tmux setenv -g tmux_version "$tmux_version"
-
-#echo "{'version' : '${tmux_version}', 'sed_pat' : '${version_pat}' }" > ~/.tmux_version.json
-
-#is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
-#    | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|l?n?vim?x?|fzf)(diff)?$'"
-#tmux if-shell -b '[ "$(echo "$tmux_version < 3.0" | bc)" = 1 ]' \
-#  "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\'  'select-pane -l'"
-#tmux if-shell -b '[ "$(echo "$tmux_version >= 3.0" | bc)" = 1 ]' \
-#  "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\\\'  'select-pane -l'"
-#tmux bind-key -T copy-mode-vi C-\\ select-pane -l
+# Restoring clear screen
+tmux bind C-l send-keys 'C-l'
 


### PR DESCRIPTION
Hello :wave:

as someone who loves TPM but uses a different key binding for pane navigation, I was a bit annoyed that the provided TPM plugin does not support configuring the key mapping for navigation. Of course, someone could resort to copying the provided setting to their .tmux.conf (or even fork this project), but I believe in using plugins to keep the config clean.

Thus, I've updated the plugin to support parameters for configuring the key mapping. It is possible to have multiple keys for each navigation action, as well as disable an individual mapping if desired. Have a look in the updated README to see how it works.

I've tested my changes in tmux version 3.2a, 3.4, as well as 2.9a (as the configuration parsing had some breaking changes in version 3.0). I hope I didn't miss any weird corner case.