### PR TITLE
Fix lazy.nvim where most recent stable release doesn't read keybinds (Vim -> tmux broken)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ If you are using [lazy.nvim](https://github.com/folke/lazy.nvim). Add the follow
 ```lua
 {
   "christoomey/vim-tmux-navigator",
+  event = "Very Lazy",
   cmd = {
     "TmuxNavigateLeft",
     "TmuxNavigateDown",

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ If you are using [lazy.nvim](https://github.com/folke/lazy.nvim). Add the follow
 ```lua
 {
   "christoomey/vim-tmux-navigator",
-  event = "Very Lazy",
+  event = "VeryLazy",
   cmd = {
     "TmuxNavigateLeft",
     "TmuxNavigateDown",

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ If you are using [lazy.nvim](https://github.com/folke/lazy.nvim). Add the follow
 ```lua
 {
   "christoomey/vim-tmux-navigator",
-  event = "VeryLazy",
+     -- Fixes a bug in lazy.nvim 10.20.3, uncomment if keybinds are unresponsive
+     -- event = "VeryLazy",
   cmd = {
     "TmuxNavigateLeft",
     "TmuxNavigateDown",


### PR DESCRIPTION
I had to change my plugin configuration for lazy.nvim for my keybinds within neovim to work, I added event type "VeryLazy" because that is what [this](https://www.lazyvim.org/configuration/general#keymaps) part of the lazyvim documentation seemed to suggest. 

That being said I understand that other users have had success using event type "BufPreRead" and I'm not sure if that one could be better in some way.

**Here are the issues that this relates to:**
#381 
#379 
#294 
