### PR TITLE
use nnoremap instead of noremap

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,16 +140,16 @@ Add the following to your `~/.vimrc` to define your custom maps:
 ``` vim
 let g:tmux_navigator_no_mappings = 1
 
-noremap <silent> {Left-Mapping} :<C-U>TmuxNavigateLeft<cr>
-noremap <silent> {Down-Mapping} :<C-U>TmuxNavigateDown<cr>
-noremap <silent> {Up-Mapping} :<C-U>TmuxNavigateUp<cr>
-noremap <silent> {Right-Mapping} :<C-U>TmuxNavigateRight<cr>
-noremap <silent> {Previous-Mapping} :<C-U>TmuxNavigatePrevious<cr>
+nnoremap <silent> {Left-Mapping} :<C-U>TmuxNavigateLeft<cr>
+nnoremap <silent> {Down-Mapping} :<C-U>TmuxNavigateDown<cr>
+nnoremap <silent> {Up-Mapping} :<C-U>TmuxNavigateUp<cr>
+nnoremap <silent> {Right-Mapping} :<C-U>TmuxNavigateRight<cr>
+nnoremap <silent> {Previous-Mapping} :<C-U>TmuxNavigatePrevious<cr>
 ```
 
 *Note* Each instance of `{Left-Mapping}` or `{Down-Mapping}` must be replaced
 in the above code with the desired mapping. Ie, the mapping for `<ctrl-h>` =>
-Left would be created with `noremap <silent> <c-h> :<C-U>TmuxNavigateLeft<cr>`.
+Left would be created with `nnoremap <silent> <c-h> :<C-U>TmuxNavigateLeft<cr>`.
 
 ##### Autosave on leave
 

--- a/doc/tmux-navigator.txt
+++ b/doc/tmux-navigator.txt
@@ -30,10 +30,10 @@ CONFIGURATION                             *tmux-navigator-configuration*
 * Custom Key Bindings
  let g:tmux_navigator_no_mappings = 1
 
- noremap <silent> {Left-mapping} :<C-U>TmuxNavigateLeft<cr>
- noremap <silent> {Down-Mapping} :<C-U>TmuxNavigateDown<cr>
- noremap <silent> {Up-Mapping} :<C-U>TmuxNavigateUp<cr>
- noremap <silent> {Right-Mapping} :<C-U>TmuxNavigateRight<cr>
- noremap <silent> {Previous-Mapping} :<C-U><C-U>TmuxNavigatePrevious<cr>
+ nnoremap <silent> {Left-mapping} :<C-U>TmuxNavigateLeft<cr>
+ nnoremap <silent> {Down-Mapping} :<C-U>TmuxNavigateDown<cr>
+ nnoremap <silent> {Up-Mapping} :<C-U>TmuxNavigateUp<cr>
+ nnoremap <silent> {Right-Mapping} :<C-U>TmuxNavigateRight<cr>
+ nnoremap <silent> {Previous-Mapping} :<C-U><C-U>TmuxNavigatePrevious<cr>
 
  vim:tw=78:ts=8:ft=help:norl:

--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -16,11 +16,11 @@ function! s:VimNavigate(direction)
 endfunction
 
 if !get(g:, 'tmux_navigator_no_mappings', 0)
-  noremap <silent> <c-h> :<C-U>TmuxNavigateLeft<cr>
-  noremap <silent> <c-j> :<C-U>TmuxNavigateDown<cr>
-  noremap <silent> <c-k> :<C-U>TmuxNavigateUp<cr>
-  noremap <silent> <c-l> :<C-U>TmuxNavigateRight<cr>
-  noremap <silent> <c-\> :<C-U>TmuxNavigatePrevious<cr>
+  nnoremap <silent> <c-h> :<C-U>TmuxNavigateLeft<cr>
+  nnoremap <silent> <c-j> :<C-U>TmuxNavigateDown<cr>
+  nnoremap <silent> <c-k> :<C-U>TmuxNavigateUp<cr>
+  nnoremap <silent> <c-l> :<C-U>TmuxNavigateRight<cr>
+  nnoremap <silent> <c-\> :<C-U>TmuxNavigatePrevious<cr>
 endif
 
 if empty($TMUX)


### PR DESCRIPTION
resolve #388, use `nnoremap` instead of `noremap` to avoid conflicts in other modes