### PR TITLE
fix: workaround netrw mapping for ctrl-L

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,27 @@ instead of having to use a different prefix (ctrl-a by default) which you may
 find convenient. If not, simply remove the lines that set/unset the prefix key
 from the code example above.
 
+#### netrw
+
+Vim's builtin file explorer, named the netrw plugin, has a default keymapping
+for `<C-l>`. When using `vim-tmux-navigator` with default settings,
+`vim-tmux-navigator` will try to override the netrw mapping so that `<C-l>` will
+still be mapped to `:TmuxNavigateRight` as it is for other buffers. If you
+prefer to keep the netrw mapping, set this variable in your vimrc:
+
+``` vim
+let g:tmux_navigator_disable_netrw_workaround = 1
+```
+
+Alternatively, if you prefer to work around the issue yourself, you can add the
+following to your vimrc:
+
+``` vim
+let g:tmux_navigator_disable_netrw_workaround = 1
+" g:Netrw_UserMaps is a list of lists. If you'd like to add other key mappings,
+" just add them like so: [['a', 'command1'], ['b', 'command2'], ...]
+let g:Netrw_UserMaps = [['<C-l>', '<C-U>TmuxNavigateRight<cr>']]
+```
 
 Troubleshooting
 ---------------

--- a/doc/tmux-navigator.txt
+++ b/doc/tmux-navigator.txt
@@ -36,4 +36,7 @@ CONFIGURATION                             *tmux-navigator-configuration*
  nnoremap <silent> {Right-Mapping} :<C-U>TmuxNavigateRight<cr>
  nnoremap <silent> {Previous-Mapping} :<C-U><C-U>TmuxNavigatePrevious<cr>
 
+* Disable the <C-l> remapping on netrw buffers (use netrw's mapping)
+ let g:tmux_navigator_disable_netrw_workaround = 1
+
  vim:tw=78:ts=8:ft=help:norl:

--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -21,6 +21,14 @@ if !get(g:, 'tmux_navigator_no_mappings', 0)
   nnoremap <silent> <c-k> :<C-U>TmuxNavigateUp<cr>
   nnoremap <silent> <c-l> :<C-U>TmuxNavigateRight<cr>
   nnoremap <silent> <c-\> :<C-U>TmuxNavigatePrevious<cr>
+
+  if !get(g:, 'tmux_navigator_disable_netrw_workaround', 0)
+    if !exists('g:Netrw_UserMaps')
+      let g:Netrw_UserMaps = [['<C-l>', '<C-U>TmuxNavigateRight<cr>']]
+    else
+      echohl ErrorMsg | echo 'vim-tmux-navigator conflicts with netrw <C-l> mapping. See https://github.com/christoomey/vim-tmux-navigator#netrw or add `let g:tmux_navigator_disable_netrw_workaround = 1` to suppress this warning.' | echohl None
+    endif
+  endif
 endif
 
 if empty($TMUX)


### PR DESCRIPTION
This adds a workaround for the netrw keymapping conflict for ctrl-l by setting the `g:Netrw_UserMaps` list. To limit the impact to users, this will leave the list alone if the user has already set the variable and instead gives a warning to prompt the user about the issue.

This mapping workaround can be disabled by setting either `g:tmux_navigator_no_mappings` or
`g:tmux_navigator_disable_netrw_workaround`.

This makes PR #392 obsolete.

Fixes #189, Fixes #251, Fixes #379