### PR TITLE
Changed all `select-pane` calls to include the -Z option

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,21 +92,21 @@ Add the following to your `~/.tmux.conf` file:
 # See: https://github.com/christoomey/vim-tmux-navigator
 is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
     | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|l?n?vim?x?|fzf)(diff)?$'"
-bind-key -n 'C-h' if-shell "$is_vim" 'send-keys C-h'  'select-pane -L'
-bind-key -n 'C-j' if-shell "$is_vim" 'send-keys C-j'  'select-pane -D'
-bind-key -n 'C-k' if-shell "$is_vim" 'send-keys C-k'  'select-pane -U'
-bind-key -n 'C-l' if-shell "$is_vim" 'send-keys C-l'  'select-pane -R'
+bind-key -n 'C-h' if-shell "$is_vim" 'send-keys C-h'  'select-pane -ZL'
+bind-key -n 'C-j' if-shell "$is_vim" 'send-keys C-j'  'select-pane -ZD'
+bind-key -n 'C-k' if-shell "$is_vim" 'send-keys C-k'  'select-pane -ZU'
+bind-key -n 'C-l' if-shell "$is_vim" 'send-keys C-l'  'select-pane -ZR'
 tmux_version='$(tmux -V | sed -En "s/^tmux ([0-9]+(.[0-9]+)?).*/\1/p")'
 if-shell -b '[ "$(echo "$tmux_version < 3.0" | bc)" = 1 ]' \
-    "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\'  'select-pane -l'"
+    "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\'  'select-pane -Zl'"
 if-shell -b '[ "$(echo "$tmux_version >= 3.0" | bc)" = 1 ]' \
-    "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\\\'  'select-pane -l'"
+    "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\\\'  'select-pane -Zl'"
 
-bind-key -T copy-mode-vi 'C-h' select-pane -L
-bind-key -T copy-mode-vi 'C-j' select-pane -D
-bind-key -T copy-mode-vi 'C-k' select-pane -U
-bind-key -T copy-mode-vi 'C-l' select-pane -R
-bind-key -T copy-mode-vi 'C-\' select-pane -l
+bind-key -T copy-mode-vi 'C-h' select-pane -ZL
+bind-key -T copy-mode-vi 'C-j' select-pane -ZD
+bind-key -T copy-mode-vi 'C-k' select-pane -ZU
+bind-key -T copy-mode-vi 'C-l' select-pane -ZR
+bind-key -T copy-mode-vi 'C-\' select-pane -Zl
 ```
 
 #### TPM
@@ -266,15 +266,15 @@ to conditionally wrap based on position on screen:
 ```tmux
 is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
     | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|l?n?vim?x?|fzf)(diff)?$'"
-bind-key -n 'C-h' if-shell "$is_vim" { send-keys C-h } { if-shell -F '#{pane_at_left}'   {} { select-pane -L } }
-bind-key -n 'C-j' if-shell "$is_vim" { send-keys C-j } { if-shell -F '#{pane_at_bottom}' {} { select-pane -D } }
-bind-key -n 'C-k' if-shell "$is_vim" { send-keys C-k } { if-shell -F '#{pane_at_top}'    {} { select-pane -U } }
-bind-key -n 'C-l' if-shell "$is_vim" { send-keys C-l } { if-shell -F '#{pane_at_right}'  {} { select-pane -R } }
+bind-key -n 'C-h' if-shell "$is_vim" { send-keys C-h } { if-shell -F '#{pane_at_left}'   {} { select-pane -ZL } }
+bind-key -n 'C-j' if-shell "$is_vim" { send-keys C-j } { if-shell -F '#{pane_at_bottom}' {} { select-pane -ZD } }
+bind-key -n 'C-k' if-shell "$is_vim" { send-keys C-k } { if-shell -F '#{pane_at_top}'    {} { select-pane -ZU } }
+bind-key -n 'C-l' if-shell "$is_vim" { send-keys C-l } { if-shell -F '#{pane_at_right}'  {} { select-pane -ZR } }
 
-bind-key -T copy-mode-vi 'C-h' if-shell -F '#{pane_at_left}'   {} { select-pane -L }
-bind-key -T copy-mode-vi 'C-j' if-shell -F '#{pane_at_bottom}' {} { select-pane -D }
-bind-key -T copy-mode-vi 'C-k' if-shell -F '#{pane_at_top}'    {} { select-pane -U }
-bind-key -T copy-mode-vi 'C-l' if-shell -F '#{pane_at_right}'  {} { select-pane -R }
+bind-key -T copy-mode-vi 'C-h' if-shell -F '#{pane_at_left}'   {} { select-pane -ZL }
+bind-key -T copy-mode-vi 'C-j' if-shell -F '#{pane_at_bottom}' {} { select-pane -ZD }
+bind-key -T copy-mode-vi 'C-k' if-shell -F '#{pane_at_top}'    {} { select-pane -ZU }
+bind-key -T copy-mode-vi 'C-l' if-shell -F '#{pane_at_right}'  {} { select-pane -ZR }
 ```
 
 #### Nesting
@@ -300,11 +300,11 @@ directly. These following fallback mappings can be targeted to the right Tmux
 session by escaping the prefix (Tmux' `send-prefix` command).
 
 ``` tmux
-bind -r C-h run "tmux select-pane -L"
-bind -r C-j run "tmux select-pane -D"
-bind -r C-k run "tmux select-pane -U"
-bind -r C-l run "tmux select-pane -R"
-bind -r C-\ run "tmux select-pane -l"
+bind -r C-h run "tmux select-pane -ZL"
+bind -r C-j run "tmux select-pane -ZD"
+bind -r C-k run "tmux select-pane -ZU"
+bind -r C-l run "tmux select-pane -ZR"
+bind -r C-\ run "tmux select-pane -Zl"
 ```
 
 Another workaround is to configure tmux on the outer machine to send keys to

--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -130,7 +130,7 @@ function! s:TmuxAwareNavigate(direction)
       catch /^Vim\%((\a\+)\)\=:E141/ " catches the no file name error
       endtry
     endif
-    let args = 'select-pane -t ' . shellescape($TMUX_PANE) . ' -' . tr(a:direction, 'phjkl', 'lLDUR')
+    let args = 'select-pane -Zt ' . shellescape($TMUX_PANE) . ' -' . tr(a:direction, 'phjkl', 'lLDUR')
     if g:tmux_navigator_preserve_zoom == 1
       let l:args .= ' -Z'
     endif

--- a/vim-tmux-navigator.tmux
+++ b/vim-tmux-navigator.tmux
@@ -4,22 +4,22 @@ version_pat='s/^tmux[^0-9]*([.0-9]+).*/\1/p'
 
 is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
     | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|l?n?vim?x?|fzf)(diff)?$'"
-tmux bind-key -n C-h if-shell "$is_vim" "send-keys C-h" "select-pane -L"
-tmux bind-key -n C-j if-shell "$is_vim" "send-keys C-j" "select-pane -D"
-tmux bind-key -n C-k if-shell "$is_vim" "send-keys C-k" "select-pane -U"
-tmux bind-key -n C-l if-shell "$is_vim" "send-keys C-l" "select-pane -R"
+tmux bind-key -n C-h if-shell "$is_vim" "send-keys C-h" "select-pane -ZL"
+tmux bind-key -n C-j if-shell "$is_vim" "send-keys C-j" "select-pane -ZD"
+tmux bind-key -n C-k if-shell "$is_vim" "send-keys C-k" "select-pane -ZU"
+tmux bind-key -n C-l if-shell "$is_vim" "send-keys C-l" "select-pane -ZR"
 tmux_version="$(tmux -V | sed -En "$version_pat")"
 tmux setenv -g tmux_version "$tmux_version"
 
 #echo "{'version' : '${tmux_version}', 'sed_pat' : '${version_pat}' }" > ~/.tmux_version.json
 
 tmux if-shell -b '[ "$(echo "$tmux_version < 3.0" | bc)" = 1 ]' \
-  "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\'  'select-pane -l'"
+  "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\'  'select-pane -Zl'"
 tmux if-shell -b '[ "$(echo "$tmux_version >= 3.0" | bc)" = 1 ]' \
-  "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\\\'  'select-pane -l'"
+  "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\\\'  'select-pane -Zl'"
 
-tmux bind-key -T copy-mode-vi C-h select-pane -L
-tmux bind-key -T copy-mode-vi C-j select-pane -D
-tmux bind-key -T copy-mode-vi C-k select-pane -U
-tmux bind-key -T copy-mode-vi C-l select-pane -R
-tmux bind-key -T copy-mode-vi C-\\ select-pane -l
+tmux bind-key -T copy-mode-vi C-h select-pane -ZL
+tmux bind-key -T copy-mode-vi C-j select-pane -ZD
+tmux bind-key -T copy-mode-vi C-k select-pane -ZU
+tmux bind-key -T copy-mode-vi C-l select-pane -ZR
+tmux bind-key -T copy-mode-vi C-\\ select-pane -Zl


### PR DESCRIPTION
Hi,

I believe the -Z option for `select-pane` is best as the default. This option makes it so that if you are zoomed into a pane, then you are still zoomed after switching to the new pane.

If you agree, here is a commit making the change.

Best,
Igor