### PR TITLE
fix: when in a "pipenv shell" can't move in between different vim/nvim windows

### DIFF
--- a/vim-tmux-navigator.tmux
+++ b/vim-tmux-navigator.tmux
@@ -3,7 +3,7 @@
 version_pat='s/^tmux[^0-9]*([.0-9]+).*/\1/p'
 
 is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
-    | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|l?n?vim?x?|fzf)(diff)?$'"
+    | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|l?n?vim?x?|fzf|pipenv)(diff)?$'"
 tmux bind-key -n C-h if-shell "$is_vim" "send-keys C-h" "select-pane -L"
 tmux bind-key -n C-j if-shell "$is_vim" "send-keys C-j" "select-pane -D"
 tmux bind-key -n C-k if-shell "$is_vim" "send-keys C-k" "select-pane -U"


### PR DESCRIPTION
Simple regex change that adds pipenv to matches
Allows switching panes and vim windows even in a pipenv shell which didn't work before