### PR TITLE
Add documentation to override navigation prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Add the following to your `~/.tmux.conf` file:
 version_pat='s/^tmux[^0-9]*([.0-9]+).*/\1/p'
 is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
     | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|l?n?vim?x?|fzf)(diff)?$'"
-nav_prefix='M'
+nav_prefix='C'
 
 bind-key -n "${nav_prefix}-h" if-shell "$is_vim" "send-keys ${nav_prefix}-h"  'select-pane -L'
 bind-key -n "${nav_prefix}-j" if-shell "$is_vim" "send-keys ${nav_prefix}-j"  'select-pane -D'

--- a/README.md
+++ b/README.md
@@ -90,23 +90,30 @@ Add the following to your `~/.tmux.conf` file:
 ``` tmux
 # Smart pane switching with awareness of Vim splits.
 # See: https://github.com/christoomey/vim-tmux-navigator
+version_pat='s/^tmux[^0-9]*([.0-9]+).*/\1/p'
 is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
     | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|l?n?vim?x?|fzf)(diff)?$'"
-bind-key -n 'C-h' if-shell "$is_vim" 'send-keys C-h'  'select-pane -L'
-bind-key -n 'C-j' if-shell "$is_vim" 'send-keys C-j'  'select-pane -D'
-bind-key -n 'C-k' if-shell "$is_vim" 'send-keys C-k'  'select-pane -U'
-bind-key -n 'C-l' if-shell "$is_vim" 'send-keys C-l'  'select-pane -R'
-tmux_version='$(tmux -V | sed -En "s/^tmux ([0-9]+(.[0-9]+)?).*/\1/p")'
-if-shell -b '[ "$(echo "$tmux_version < 3.0" | bc)" = 1 ]' \
-    "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\'  'select-pane -l'"
-if-shell -b '[ "$(echo "$tmux_version >= 3.0" | bc)" = 1 ]' \
-    "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\\\'  'select-pane -l'"
+nav_prefix='M'
 
-bind-key -T copy-mode-vi 'C-h' select-pane -L
-bind-key -T copy-mode-vi 'C-j' select-pane -D
-bind-key -T copy-mode-vi 'C-k' select-pane -U
-bind-key -T copy-mode-vi 'C-l' select-pane -R
-bind-key -T copy-mode-vi 'C-\' select-pane -l
+bind-key -n "${nav_prefix}-h" if-shell "$is_vim" "send-keys ${nav_prefix}-h"  'select-pane -L'
+bind-key -n "${nav_prefix}-j" if-shell "$is_vim" "send-keys ${nav_prefix}-j"  'select-pane -D'
+bind-key -n "${nav_prefix}-k" if-shell "$is_vim" "send-keys ${nav_prefix}-k"  'select-pane -U'
+bind-key -n "${nav_prefix}-l" if-shell "$is_vim" "send-keys ${nav_prefix}-l"  'select-pane -R'
+
+run-shell 'tmux setenv -g tmux_version $(tmux -V | sed -En "$version_pat")'
+if-shell '[ "$(echo "$tmux_version < 3.0" | bc)" = 1 ]' {
+  bind-key -n "${nav_prefix}-\\" if-shell "$is_vim" "send-keys ${nav_prefix}-\\"  'select-pane -l'
+}
+
+if-shell '[ "$(echo "$tmux_version >= 3.0" | bc)" = 1 ]' {
+  bind-key -n "${nav_prefix}-\\" if-shell "$is_vim" "send-keys ${nav_prefix}-\\\\"  'select-pane -l'
+}
+
+bind-key -T copy-mode-vi "${nav_prefix}-h" select-pane -L
+bind-key -T copy-mode-vi "${nav_prefix}-j" select-pane -D
+bind-key -T copy-mode-vi "${nav_prefix}-k" select-pane -U
+bind-key -T copy-mode-vi "${nav_prefix}-l" select-pane -R
+bind-key -T copy-mode-vi "${nav_prefix}-\\" select-pane -l
 ```
 
 #### TPM


### PR DESCRIPTION
Creating this PR to allow people to override the navigation prefix in tmux.

This can be integrated into the plugin itself along with option to override the key binding. Happy to do this now, or wait and see what ends up happening with https://github.com/christoomey/vim-tmux-navigator/pull/380, as that can change implementation details.

Let me know what you'd recommend.

Thanks :pray: 

Edit: note that this change was inspired by `CTRL+h` being interpreted as the ASCII for backspace, which broke navigation to the left. Making this configurable solves this, and also avoids needing a separate workaround for `CTRL+l` functionality.