### PR TITLE
TPM: Fix disabling key bindings

### DIFF
--- a/vim-tmux-navigator.tmux
+++ b/vim-tmux-navigator.tmux
@@ -4,17 +4,15 @@ get_tmux_option() {
   local option value default
   option="$1"
   default="$2"
-  value=$(tmux show-option -gqv "$option")
+  value="$(tmux show-option -gv "$option" 2>/dev/null || echo "$default")"
 
-  if [ -n "$value" ]; then
-    if [ "$value" = "null" ]; then
+  # Deprecated, for backward compatibility
+  if [[ $value == 'null' ]]; then
       echo ""
-    else
-      echo "$value"
-    fi
-  else
-    echo "$default"
+      return
   fi
+
+  echo "$value"
 }
 
 bind_key_vim() {


### PR DESCRIPTION
The documentation states that for the TPM plugin, key bindings could be disabled by setting the corresponding option to an empty string.

This did not work. Instead `null` could be passed to disable a binding.

This PR changes it so that the function falls back to the default value when the option is not set and allows for using an empty string to disable a mapping. Also, `null` is kept for backward compatibility.

Fixes #408 