### PR TITLE
TPM: Make the "clear screen" mapping configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,14 @@ set -g @vim_navigator_mapping_up "C-k"
 set -g @vim_navigator_mapping_down "C-j"
 set -g @vim_navigator_mapping_prev ""  # removes the C-\ binding
 ```
+
+To disable the automatic mapping of `<prefix> C-l` to `send C-l` (which is
+intended to restore the "clear screen" functionality):
+
+```tmux
+set -g @vim_navigator_prefix_mapping_clear_screen ""
+```
+
 Don't forget to run tpm:
 
 ``` tmux

--- a/vim-tmux-navigator.tmux
+++ b/vim-tmux-navigator.tmux
@@ -42,5 +42,6 @@ for k in $(echo "$move_right"); do bind_key_vim "$k" "select-pane -R"; done
 for k in $(echo "$move_prev");  do bind_key_vim "$k" "select-pane -l"; done
 
 # Restoring clear screen
-tmux bind C-l send-keys 'C-l'
+clear_screen="$(get_tmux_option "@vim_navigator_prefix_mapping_clear_screen" 'C-l')"
+for k in $(echo "$clear_screen"); do tmux bind "$k" send-keys 'C-l'; done
 


### PR DESCRIPTION
This PR adds a new option `@vim_navigator_prefix_mapping_clear_screen` that let's the user set (or disable) an alternative key binding for the "clear screen" key binding (usually `C-l`) which is overridden by the default mappings of this plugin.

Fixes #410 