### PR TITLE
Bugfix/regex does not match ps output on macos

### DIFF
--- a/vim-tmux-navigator.tmux
+++ b/vim-tmux-navigator.tmux
@@ -26,7 +26,7 @@ bind_key_vim() {
   key="$1"
   tmux_cmd="$2"
   is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
-      | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|l?n?vim?x?|fzf)(diff)?$'"
+      | grep -iqE '^ ?[^TXZ ]+ +(\\S+\\/)?g?(view|l?n?vim?x?|fzf)(diff)?$'"
   # sending C-/ according to https://github.com/tmux/tmux/issues/1827
   tmux bind-key -n "$key" if-shell "$is_vim" "send-keys '$key'" "$tmux_cmd"
   # tmux < 3.0 cannot parse "$tmux_cmd" as one argument, thus copying as multiple arguments

--- a/vim-tmux-navigator.tmux
+++ b/vim-tmux-navigator.tmux
@@ -26,7 +26,7 @@ bind_key_vim() {
   key="$1"
   tmux_cmd="$2"
   is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
-      | grep -iqE '^ ?[^TXZ ]+ +(\\S+\\/)?g?(view|l?n?vim?x?|fzf)(diff)?$'"
+      | grep -iqE '^[^TXZ]+ +(\\S+\\/)?g?(view|l?n?vim?x?|fzf)(diff)?$'"
   # sending C-/ according to https://github.com/tmux/tmux/issues/1827
   tmux bind-key -n "$key" if-shell "$is_vim" "send-keys '$key'" "$tmux_cmd"
   # tmux < 3.0 cannot parse "$tmux_cmd" as one argument, thus copying as multiple arguments


### PR DESCRIPTION
I don't know exactly why, but on Mac OS my output of `ps -o state= -o comm=` does not contain *any* characters in the first state column (or rather, all processes have a space here). Some example lines:

```
❯ ps -o state= -o comm=
 +   tmux
     -zsh
 s   -zsh
 +   docker
 +   /Applications/Docker.app/Contents/Resources/bin/com.docker.cli
 s   -sh
 +   /nix/store/rj7zvmif800bgg3sbznq6g5g438jx104-bash-5.2p37/bin/bash
 +   /nix/store/rppw7g0g21rm1ayrjiflkjagxmkwmnzh-neovim-unwrapped-0.10.2/bin/nvim
 s+  -sh
 s+  -sh
 s   -sh
 +   /nix/store/rj7zvmif800bgg3sbznq6g5g438jx104-bash-5.2p37/bin/bash
 +   /nix/store/rppw7g0g21rm1ayrjiflkjagxmkwmnzh-neovim-unwrapped-0.10.2/bin/nvim
 s   -zsh
 +   ps
```

This makes the `$is_vim` regex fail for me on MacOS, even when there is a (n)vim process running within the tty.

Not sure exactly why ` ` (space) is forbidden in the state column like it is (except as a delimeter to make sure only characters until the column end is counted, but I think the rest of the regex already makes sure the can be no mistakes about what data belongs in what column, so I think it should be safe to scrap it). Doing so solves my issues, and vim-tmux-navigator works beautifully again on MacOS (and should do so as well on Linux I believe).

Please test this and master on MacOS and Linux and see if you think it might be an improvement.