### PR TITLE
Add terminal mode navigation support with FZF compatibility fix for issue #430

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ mapping.
 
 #### Ignoring programs that use Ctrl+hjkl movement
 
-In interactive programs such as FZF, Ctrl+hjkl can be used instead of the arrow keys to move the selection up and down. If vim-tmux-navigator is getting in your way trying to change the active window instead, you can make it be ignored and work as if this plugin were not enabled. Just modify the `is_vim` variable(that you have either on the snipped you pasted on `~/.tmux.conf` or on the `vim-tmux-navigator.tmux` file). For example, to add the program `foobar`:
+In interactive programs such as FZF or the built-in Vim terminal, Ctrl+hjkl can be used instead of the arrow keys to move the selection up and down. If vim-tmux-navigator is getting in your way trying to change the active window instead, you can make it be ignored and work as if this plugin were not enabled. Just modify the `is_vim` variable(that you have either on the snipped you pasted on `~/.tmux.conf` or on the `vim-tmux-navigator.tmux` file). For example, to add the program `foobar`:
 
 ```diff
 - is_vim="ps -o state= -o comm= -t '#{pane_tty}' | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|l?n?vim?x?|fzf)(diff)?$'"
@@ -449,9 +449,7 @@ sources the non-interactive config.
 
 ### It doesn't work in Vim's `terminal` mode
 
-Terminal mode is currently unsupported as adding this plugin's mappings there
-causes conflict with movement mappings for FZF (it also uses terminal mode).
-There's a conversation about this in https://github.com/christoomey/vim-tmux-navigator/pull/172
+Terminal mode is now supported :)
 
 ### It Doesn't Work in tmate
 

--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -21,6 +21,12 @@ if !get(g:, 'tmux_navigator_no_mappings', 0)
   nnoremap <silent> <c-k> :<C-U>TmuxNavigateUp<cr>
   nnoremap <silent> <c-l> :<C-U>TmuxNavigateRight<cr>
   nnoremap <silent> <c-\> :<C-U>TmuxNavigatePrevious<cr>
+  
+
+  tnoremap <C-h> <C-w>:<C-U>TmuxNavigateLeft<cr>
+  tnoremap <C-j> <C-w>:<C-U>TmuxNavigateDown<cr>
+  tnoremap <C-k> <C-w>:<C-U>TmuxNavigateUp<cr>
+  tnoremap <C-l> <C-w>:<C-U>TmuxNavigateRight<cr>
 
   if !get(g:, 'tmux_navigator_disable_netrw_workaround', 0)
     if !exists('g:Netrw_UserMaps')

--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -23,10 +23,10 @@ if !get(g:, 'tmux_navigator_no_mappings', 0)
   nnoremap <silent> <c-\> :<C-U>TmuxNavigatePrevious<cr>
   
 
-  tnoremap <C-h> <C-w>:<C-U>TmuxNavigateLeft<cr>
-  tnoremap <C-j> <C-w>:<C-U>TmuxNavigateDown<cr>
-  tnoremap <C-k> <C-w>:<C-U>TmuxNavigateUp<cr>
-  tnoremap <C-l> <C-w>:<C-U>TmuxNavigateRight<cr>
+  tnoremap <silent> <C-h> <C-w>:<C-U> TmuxNavigateLeft<cr>
+  tnoremap <silent> <C-j> <C-w>:<C-U> TmuxNavigateDown<cr>
+  tnoremap <silent> <C-k> <C-w>:<C-U> TmuxNavigateUp<cr>
+  tnoremap <silent> <C-l> <C-w>:<C-U> TmuxNavigateRight<cr>
 
   if !get(g:, 'tmux_navigator_disable_netrw_workaround', 0)
     if !exists('g:Netrw_UserMaps')
@@ -114,7 +114,14 @@ function! s:ShouldForwardNavigationBackToTmux(tmux_last_pane, at_tab_page_edge)
   return a:tmux_last_pane || a:at_tab_page_edge
 endfunction
 
+function! IsFZF()
+  return &ft == 'fzf'
+endfunction
+
 function! s:TmuxAwareNavigate(direction)
+  if IsFZF()
+    return
+  endif
   let nr = winnr()
   let tmux_last_pane = (a:direction == 'p' && s:tmux_is_last_pane)
   if !tmux_last_pane

--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -1,5 +1,4 @@
-" Maps <C-h/j/k/l> to switch vim splits in the given direction. If there are
-" no more windows in that direction, forwards the operation to tmux.
+" Maps <C-h/j/k/l> to switch vim splits in the given direction. If there are no more windows in that direction, forwards the operation to tmux.
 " Additionally, <C-\> toggles between last active vim splits/tmux panes.
 
 if exists("g:loaded_tmux_navigator") || &cp || v:version < 700
@@ -23,10 +22,10 @@ if !get(g:, 'tmux_navigator_no_mappings', 0)
   nnoremap <silent> <c-\> :<C-U>TmuxNavigatePrevious<cr>
   
 
-  tnoremap <silent> <C-h> <C-w>:<C-U> TmuxNavigateLeft<cr>
-  tnoremap <silent> <C-j> <C-w>:<C-U> TmuxNavigateDown<cr>
-  tnoremap <silent> <C-k> <C-w>:<C-U> TmuxNavigateUp<cr>
-  tnoremap <silent> <C-l> <C-w>:<C-U> TmuxNavigateRight<cr>
+  tnoremap <expr> <silent> <C-h> IsFZF() ? "\<C-h>" : "\<C-w>:\<C-U> TmuxNavigateLeft\<cr>"
+  tnoremap <expr> <silent> <C-j> IsFZF() ? "\<C-j>" : "\<C-w>:\<C-U> TmuxNavigateDown\<cr>"
+  tnoremap <expr> <silent> <C-k> IsFZF() ? "\<C-k>" : "\<C-w>:\<C-U> TmuxNavigateUp\<cr>"
+  tnoremap <expr> <silent> <C-l> IsFZF() ? "\<C-l>" : "\<C-w>:\<C-U> TmuxNavigateRight\<cr>"
 
   if !get(g:, 'tmux_navigator_disable_netrw_workaround', 0)
     if !exists('g:Netrw_UserMaps')
@@ -119,9 +118,6 @@ function! IsFZF()
 endfunction
 
 function! s:TmuxAwareNavigate(direction)
-  if IsFZF()
-    return
-  endif
   let nr = winnr()
   let tmux_last_pane = (a:direction == 'p' && s:tmux_is_last_pane)
   if !tmux_last_pane


### PR DESCRIPTION
The current tmux-navigator plugin doesn't handle terminal mode (term) navigation seamlessly. When using terminal splits in Vim alongside tmux panes, the navigation breaks down. This functionality had been left out because it collided with Vim FZF

Solution
Added terminal mode support with FZF-awareness:

New terminal mode mappings that integrate with existing tmux navigation
Added IsFZF() function to detect when we're in FZF
Used <expr> mappings to conditionally pass through controls to FZF when appropriate