### PR TITLE
fix: ensure `IsFzf` usable when you don't use tmux

### DIFF
--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -20,8 +20,11 @@ if !get(g:, 'tmux_navigator_no_mappings', 0)
   nnoremap <silent> <c-k> :<C-U>TmuxNavigateUp<cr>
   nnoremap <silent> <c-l> :<C-U>TmuxNavigateRight<cr>
   nnoremap <silent> <c-\> :<C-U>TmuxNavigatePrevious<cr>
-  
+
   if !empty($TMUX)
+    function! IsFZF()
+      return &ft == 'fzf'
+    endfunction
     tnoremap <expr> <silent> <C-h> IsFZF() ? "\<C-h>" : "\<C-w>:\<C-U> TmuxNavigateLeft\<cr>"
     tnoremap <expr> <silent> <C-j> IsFZF() ? "\<C-j>" : "\<C-w>:\<C-U> TmuxNavigateDown\<cr>"
     tnoremap <expr> <silent> <C-k> IsFZF() ? "\<C-k>" : "\<C-w>:\<C-U> TmuxNavigateUp\<cr>"
@@ -114,9 +117,6 @@ function! s:ShouldForwardNavigationBackToTmux(tmux_last_pane, at_tab_page_edge)
   return a:tmux_last_pane || a:at_tab_page_edge
 endfunction
 
-function! IsFZF()
-  return &ft == 'fzf'
-endfunction
 
 function! s:TmuxAwareNavigate(direction)
   let nr = winnr()


### PR DESCRIPTION
Related https://github.com/ibhagwan/fzf-lua/issues/1853.
When you don't use tmux, `IsFzf` is undef.
