### PR TITLE
refactor: export 'vim_pattern' to be reused in tests

### DIFF
--- a/pattern-check
+++ b/pattern-check
@@ -11,8 +11,9 @@ GREEN=$(tput setaf 2)
 YELLOW=$(tput setaf 3)
 NORMAL=$(tput sgr0)
 
+# Import 'vim_pattern'
+source 'vim-tmux-navigator.tmux'
 
-vim_pattern='(\\S+\\/)?g?\.?(view|l?n?vim?x?|fzf)(diff)?(-wrapped)?$'
 match_tests=(vim Vim VIM vimdiff lvim /usr/local/bin/vim vi gvim view gview nvim vimx fzf .vim-wrapped .nvim-wrapped)
 no_match_tests=( /Users/christoomey/.vim/thing /usr/local/bin/start-vim )
 

--- a/vim-tmux-navigator.tmux
+++ b/vim-tmux-navigator.tmux
@@ -21,31 +21,39 @@ get_tmux_option() {
   echo "$value"
 }
 
+# Export 'vim_pattern' so that it can be tested in pattern-check
+declare vim_pattern='(\\S+\\/)?g?\.?(view|l?n?vim?x?|fzf)(diff)?(-wrapped)?$'
+
 bind_key_vim() {
   local key tmux_cmd is_vim
   key="$1"
   tmux_cmd="$2"
   is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
-      | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?\.?(view|l?n?vim?x?|fzf)(diff)?(-wrapped)?$'"
+      | grep -iqE '^[^TXZ ]+ +${vim_pattern}'"
   # sending C-/ according to https://github.com/tmux/tmux/issues/1827
   tmux bind-key -n "$key" if-shell "$is_vim" "send-keys '$key'" "$tmux_cmd"
   # tmux < 3.0 cannot parse "$tmux_cmd" as one argument, thus copying as multiple arguments
   tmux bind-key -T copy-mode-vi "$key" $tmux_cmd
 }
 
-move_left="$(get_tmux_option "@vim_navigator_mapping_left" 'C-h')"
-move_right="$(get_tmux_option "@vim_navigator_mapping_right" 'C-l')"
-move_up="$(get_tmux_option "@vim_navigator_mapping_up" 'C-k')"
-move_down="$(get_tmux_option "@vim_navigator_mapping_down" 'C-j')"
-move_prev="$(get_tmux_option "@vim_navigator_mapping_prev" 'C-\')"
+main() {
+  move_left="$(get_tmux_option "@vim_navigator_mapping_left" 'C-h')"
+  move_right="$(get_tmux_option "@vim_navigator_mapping_right" 'C-l')"
+  move_up="$(get_tmux_option "@vim_navigator_mapping_up" 'C-k')"
+  move_down="$(get_tmux_option "@vim_navigator_mapping_down" 'C-j')"
+  move_prev="$(get_tmux_option "@vim_navigator_mapping_prev" 'C-\')"
 
-for k in $(echo "$move_left");  do bind_key_vim "$k" "select-pane -L"; done
-for k in $(echo "$move_down");  do bind_key_vim "$k" "select-pane -D"; done
-for k in $(echo "$move_up");    do bind_key_vim "$k" "select-pane -U"; done
-for k in $(echo "$move_right"); do bind_key_vim "$k" "select-pane -R"; done
-for k in $(echo "$move_prev");  do bind_key_vim "$k" "select-pane -l"; done
+  for k in $(echo "$move_left");  do bind_key_vim "$k" "select-pane -L"; done
+  for k in $(echo "$move_down");  do bind_key_vim "$k" "select-pane -D"; done
+  for k in $(echo "$move_up");    do bind_key_vim "$k" "select-pane -U"; done
+  for k in $(echo "$move_right"); do bind_key_vim "$k" "select-pane -R"; done
+  for k in $(echo "$move_prev");  do bind_key_vim "$k" "select-pane -l"; done
 
-# Restoring clear screen
-clear_screen="$(get_tmux_option "@vim_navigator_prefix_mapping_clear_screen" 'C-l')"
-for k in $(echo "$clear_screen"); do tmux bind "$k" send-keys 'C-l'; done
+  # Restoring clear screen
+  clear_screen="$(get_tmux_option "@vim_navigator_prefix_mapping_clear_screen" 'C-l')"
+  for k in $(echo "$clear_screen"); do tmux bind "$k" send-keys 'C-l'; done
+}
 
+if [ "$BASH_SOURCE" == "$0" ]; then
+  main "$@"
+fi


### PR DESCRIPTION
This refactors the code into a 'main' function. This lets the test code (pattern-check) import the actual source file and run tests against the actual 'vim_pattern' directly.

Test: `bash pattern-check`
Test: I also tested by running `tmux kill-server` and reloading. This plugin is still sourced and loaded as expected.