### PR TITLE
test: introduce extra backslash evaluation in test

### DIFF
--- a/pattern-check
+++ b/pattern-check
@@ -53,7 +53,12 @@ display_matches() {
 }
 
 matches_vim_pattern() {
-  if echo "$1" | grep -iqE "$vim_pattern"; then
+  # Need to do an extra round of 'echo -en' in order to expand the '\'
+  # characters one extra time. This is necessary because
+  # vim-tmux-navigator.tmux uses the '$vim_pattern' variable inside of
+  # 'if-shell' which does its own round of '\' evaluation.
+  local expanded_vim_pattern="$(echo -en "${vim_pattern}")"
+  if echo "$1" | grep -iqE "${expanded_vim_pattern}"; then
     echo "${MATCH_RESULT}"
   else
     echo "${NO_MATCH_RESULT}"

--- a/vim-tmux-navigator.tmux
+++ b/vim-tmux-navigator.tmux
@@ -22,6 +22,8 @@ get_tmux_option() {
 }
 
 # Export 'vim_pattern' so that it can be tested in pattern-check
+# Note: any backslash sequence needs an extra '\' character. This is because the
+# backslashes are expanded an extra time by the 'if-shell' command.
 declare vim_pattern='(\\S+\\/)?g?\.?(view|l?n?vim?x?|fzf)(diff)?(-wrapped)?$'
 
 bind_key_vim() {


### PR DESCRIPTION
No change to production logic or behavior. I realized in #451 that there is an extra round of backslash expansion which happens in the prod environment but not the test environment. This updates the test environment to also have an extra round evaluation to match. This change should result in more reliable unit tests.

Issue #451
Test: bash pattern-check
Test: tmux kill-server and verify manually with multiple splits + nvim