### PR TITLE
Fix failing unit test (reland)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ Add the following to your `~/.tmux.conf` file:
 ``` tmux
 # Smart pane switching with awareness of Vim splits.
 # See: https://github.com/christoomey/vim-tmux-navigator
-vim_pattern='(\\S+\\/)?g?\.?(view|l?n?vim?x?|fzf)(diff)?(-wrapped)?$'
+vim_pattern='(\S+/)?g?\.?(view|l?n?vim?x?|fzf)(diff)?(-wrapped)?'
 is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
-    | grep -iqE '^[^TXZ ]+ +${vim_pattern}'"
+    | grep -iqE '^[^TXZ ]+ +${vim_pattern}$'"
 bind-key -n 'C-h' if-shell "$is_vim" 'send-keys C-h'  'select-pane -L'
 bind-key -n 'C-j' if-shell "$is_vim" 'send-keys C-j'  'select-pane -D'
 bind-key -n 'C-k' if-shell "$is_vim" 'send-keys C-k'  'select-pane -U'
@@ -244,10 +244,10 @@ mapping.
 In interactive programs such as FZF or the built-in Vim terminal, Ctrl+hjkl can be used instead of the arrow keys to move the selection up and down. If vim-tmux-navigator is getting in your way trying to change the active window instead, you can make it be ignored and work as if this plugin were not enabled. Just modify the `is_vim` variable(that you have either on the snipped you pasted on `~/.tmux.conf` or on the `vim-tmux-navigator.tmux` file). For example, to add the program `foobar`:
 
 ```diff
-- vim_pattern='(\\S+\\/)?g?\.?(view|l?n?vim?x?|fzf)(diff)?(-wrapped)?$'
-+ vim_pattern='(\\S+\\/)?g?\.?(view|l?n?vim?x?|fzf|foobar)(diff)?(-wrapped)?$'
+- vim_pattern='(\S+/)?g?\.?(view|l?n?vim?x?|fzf)(diff)?(-wrapped)?'
++ vim_pattern='(\S+/)?g?\.?(view|l?n?vim?x?|fzf|foobar)(diff)?(-wrapped)?'
 is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
-    | grep -iqE '^[^TXZ ]+ +${vim_pattern}'"
+    | grep -iqE '^[^TXZ ]+ +${vim_pattern}$'"
 ```
 
 #### Restoring Clear Screen (C-l)
@@ -294,9 +294,9 @@ Tmux doesn't have an option, so whatever key bindings you have need to be set
 to conditionally wrap based on position on screen:
 
 ```tmux
-vim_pattern='(\\S+\\/)?g?\.?(view|l?n?vim?x?|fzf)(diff)?(-wrapped)?$'
+vim_pattern='(\S+/)?g?\.?(view|l?n?vim?x?|fzf)(diff)?(-wrapped)?'
 is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
-    | grep -iqE '^[^TXZ ]+ +${vim_pattern}'"
+    | grep -iqE '^[^TXZ ]+ +${vim_pattern}$'"
 bind-key -n 'C-h' if-shell "$is_vim" { send-keys C-h } { if-shell -F '#{pane_at_left}'   {} { select-pane -L } }
 bind-key -n 'C-j' if-shell "$is_vim" { send-keys C-j } { if-shell -F '#{pane_at_bottom}' {} { select-pane -D } }
 bind-key -n 'C-k' if-shell "$is_vim" { send-keys C-k } { if-shell -F '#{pane_at_top}'    {} { select-pane -U } }
@@ -479,15 +479,15 @@ If this doesn't solve your problem, you can also try the following:
 
 Replace the `is_vim` variable in your `~/.tmux.conf` file with:
 ```tmux
-vim_pattern='(\\S+/)?(^|/)g?\.?(view|l?n?vim?x?|fzf)(diff)?(-wrapped)?$'
+vim_pattern='(\S+/)?g?\.?(view|l?n?vim?x?|fzf)(diff)?(-wrapped)?'
 if-shell '[ -f /.dockerenv ]' \
   "is_vim=\"ps -o state=,comm= -t '#{pane_tty}' \
-      | grep -iqE '^[^TXZ ]+ +${vim_pattern}'\""
+      | grep -iqE '^[^TXZ ]+ +${vim_pattern}$'\""
   # Filter out docker instances of nvim from the host system to prevent
   # host from thinking nvim is running in a pseudoterminal when its not.
   "is_vim=\"ps -o state=,comm=,cgroup= -t '#{pane_tty}' \
       | grep -ivE '^.+ +.+ +.+\\/docker\\/.+$' \
-      | grep -iqE '^[^TXZ ]+ +${vim_pattern}'\""
+      | grep -iqE '^[^TXZ ]+ +${vim_pattern}$'\""
 ```
 
 Details: The output of the ps command on the host system includes processes

--- a/pattern-check
+++ b/pattern-check
@@ -33,7 +33,7 @@ match_tests=(
 )
 no_match_tests=(
   /Users/christoomey/.vim/thing
-  # /usr/local/bin/start-vim
+  /usr/local/bin/start-vim
 )
 
 MATCH_RESULT="${GREEN}match${NORMAL}"
@@ -53,7 +53,7 @@ display_matches() {
 }
 
 matches_vim_pattern() {
-  if echo "$1" | grep -iqE "$vim_pattern"; then
+  if echo "$1" | grep -iqE "^${vim_pattern}$"; then
     echo "${MATCH_RESULT}"
   else
     echo "${NO_MATCH_RESULT}"

--- a/vim-tmux-navigator.tmux
+++ b/vim-tmux-navigator.tmux
@@ -22,14 +22,14 @@ get_tmux_option() {
 }
 
 # Export 'vim_pattern' so that it can be tested in pattern-check
-declare vim_pattern='(\\S+\\/)?g?\.?(view|l?n?vim?x?|fzf)(diff)?(-wrapped)?$'
+declare vim_pattern='(\S+/)?g?\.?(view|l?n?vim?x?|fzf)(diff)?(-wrapped)?'
 
 bind_key_vim() {
   local key tmux_cmd is_vim
   key="$1"
   tmux_cmd="$2"
   is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
-      | grep -iqE '^[^TXZ ]+ +${vim_pattern}'"
+      | grep -iqE '^[^TXZ ]+ +${vim_pattern}$'"
   # sending C-/ according to https://github.com/tmux/tmux/issues/1827
   tmux bind-key -n "$key" if-shell "$is_vim" "send-keys '$key'" "$tmux_cmd"
   # tmux < 3.0 cannot parse "$tmux_cmd" as one argument, thus copying as multiple arguments


### PR DESCRIPTION
This is a reland attempt to fix the failing unit test ('start-vim').
This is a reland of #451 but with a regex fix to avoid bugs in the prod
environment.

Fixes #451
Test: bash pattern-check
Test: manual