### PR TITLE
Revert "test: introduce extra backslash evaluation in test (#454)"

### DIFF
--- a/pattern-check
+++ b/pattern-check
@@ -53,12 +53,7 @@ display_matches() {
 }
 
 matches_vim_pattern() {
-  # Need to do an extra round of 'echo -en' in order to expand the '\'
-  # characters one extra time. This is necessary because
-  # vim-tmux-navigator.tmux uses the '$vim_pattern' variable inside of
-  # 'if-shell' which does its own round of '\' evaluation.
-  local expanded_vim_pattern="$(echo -en "${vim_pattern}")"
-  if echo "$1" | grep -iqE "${expanded_vim_pattern}"; then
+  if echo "$1" | grep -iqE "$vim_pattern"; then
     echo "${MATCH_RESULT}"
   else
     echo "${NO_MATCH_RESULT}"

--- a/vim-tmux-navigator.tmux
+++ b/vim-tmux-navigator.tmux
@@ -22,8 +22,6 @@ get_tmux_option() {
 }
 
 # Export 'vim_pattern' so that it can be tested in pattern-check
-# Note: any backslash sequence needs an extra '\' character. This is because the
-# backslashes are expanded an extra time by the 'if-shell' command.
 declare vim_pattern='(\\S+\\/)?g?\.?(view|l?n?vim?x?|fzf)(diff)?(-wrapped)?$'
 
 bind_key_vim() {


### PR DESCRIPTION
This reverts commit ad4c04239d970981942d6a3e1195a770df09d0d7.

Upon further inspection, I realized this was actually not the right cause for the breakage in #451.