### PR TITLE
docs: update vim_pattern in README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,11 +318,17 @@ By default this plugin works on the outermost tmux session and the vim
 sessions it contains, but you can customize the behaviour by adding more
 commands to the expression used by the grep command.
 
-When nesting tmux sessions via ssh or mosh, you could extend it to look like
-`'(^|\/)g?(view|vim|ssh|mosh?)(diff)?$'`, which makes this plugin work within
-the innermost tmux session and the vim sessions within that one. This works
-better than the default behaviour if you use the outer Tmux sessions as relays
-to different hosts and have all instances of vim on remote hosts.
+When nesting tmux sessions via ssh or mosh, you could extend it to look like:
+
+```diff
+- vim_pattern='(\S+/)?g?\.?(view|l?n?vim?x?|fzf)(diff)?(-wrapped)?'
++ vim_pattern='(\S+/)?g?\.?(view|l?n?vim?x?|fzf|ssh|mosh)(diff)?(-wrapped)?'
+```
+
+This configuration makes this plugin work within the innermost tmux session and
+the vim sessions within that one. This works better than the default behaviour
+if you use the outer Tmux sessions as relays to different hosts and have all
+instances of vim on remote hosts.
 
 Similarly, if you like to nest tmux locally, add `|tmux` to the expression.
 

--- a/pattern-check
+++ b/pattern-check
@@ -83,6 +83,34 @@ main() {
   else
     echo -e "\n${RED}Some test cases are failing${NORMAL}"
   fi
+
+  # Find lines in README.md which redefine 'vim_pattern' so that we can make
+  # sure it matches the canonical definition in vim-tmux-navigator.tmux. This
+  # includes lines starting with '- vim_pattern', however it skips
+  # '+ vim_pattern' since those lines indicate intentional modifications and
+  # need manual review.
+  IFS='
+'
+  local -a pattern_copies=($(sed -En "s/^\s*(- )?vim_pattern='(.*)'/\2/p" README.md))
+
+  local pattern_copy
+  local readme_status=0
+  echo -e "\nChecking README.md documentation"
+  for pattern_copy in "${pattern_copies[@]}"; do
+    if [[ "${vim_pattern}" != "${pattern_copy}" ]]; then
+      echo -n "Update 'vim_pattern' in README.md "
+      echo -n "(current line: ${RED}'${pattern_copy}'${NORMAL}) "
+      echo "to match ${GREEN}'${vim_pattern}'${NORMAL}"
+      readme_status=1
+    fi
+  done
+  if [[ "${readme_status}" == 0 ]]; then
+    echo -e "\n${GREEN}README.md is up to date${NORMAL}"
+  else
+    echo -e "\n${RED}Update README.md to fix defintions of 'vim_pattern'${NORMAL}"
+    final_status="${readme_status}"
+  fi
+
   return "${final_status}"
 }
 


### PR DESCRIPTION
This fixes one spot where `vim_pattern` was stale in the README.md file. This also adds a check for this inside of the pattern-check test file to try to catch when `vim_pattern` changes but the README documentation hasn't been updated.

Test: bash pattern-check