### PR TITLE
feat: faster vim detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,11 @@ Add the following to your `~/.tmux.conf` file:
 # Smart pane switching with awareness of Vim splits.
 # See: https://github.com/christoomey/vim-tmux-navigator
 vim_pattern='(\S+/)?g?\.?(view|l?n?vim?x?|fzf)(diff)?(-wrapped)?'
-is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
-    | grep -iqE '^[^TXZ ]+ +${vim_pattern}$'"
+is_vim="\
+echo '#{pane_current_command}' | grep -iqE '^${vim_pattern}$' && exit 0
+echo '#{pane_current_command}' | grep -iqE '^(bash|zsh|fish)$' && exit 1
+ps -o state= -o comm= -t '#{pane_tty}' \
+  | grep -iqE '^[^TXZ ]+ +${vim_pattern}'"
 bind-key -n 'C-h' if-shell "$is_vim" 'send-keys C-h'  'select-pane -L'
 bind-key -n 'C-j' if-shell "$is_vim" 'send-keys C-j'  'select-pane -D'
 bind-key -n 'C-k' if-shell "$is_vim" 'send-keys C-k'  'select-pane -U'


### PR DESCRIPTION
I noticed that the `ps` command is very slow (~200 ms) on one of my machines. This makes pane switching slow both inside vim and in tmux.

This change uses `#{pane_current_command}` as a first attempt to mitigate the slowdown, with a fallback to the current logic. This first attempt handles most important cases (invoking `vim` directly or inside an interactive shell).

Test: bash pattern-check
Test: manual: add `sleep 0.2` before `ps` to simulate the slowdown