### PR TITLE
Support navigating from Neovim terminals in insert mode

### DIFF
--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -25,10 +25,13 @@ if !get(g:, 'tmux_navigator_no_mappings', 0)
     function! IsFZF()
       return &ft == 'fzf'
     endfunction
-    tnoremap <expr> <silent> <C-h> IsFZF() ? "\<C-h>" : "\<C-w>:\<C-U> TmuxNavigateLeft\<cr>"
-    tnoremap <expr> <silent> <C-j> IsFZF() ? "\<C-j>" : "\<C-w>:\<C-U> TmuxNavigateDown\<cr>"
-    tnoremap <expr> <silent> <C-k> IsFZF() ? "\<C-k>" : "\<C-w>:\<C-U> TmuxNavigateUp\<cr>"
-    tnoremap <expr> <silent> <C-l> IsFZF() ? "\<C-l>" : "\<C-w>:\<C-U> TmuxNavigateRight\<cr>"
+
+    let g:tmux_navigator_term_init_command = has('nvim') ? "\<C-\>\<C-N>" : "\<C-W>"
+
+    tnoremap <expr> <silent> <C-h> IsFZF() ? "\<C-h>" : g:tmux_navigator_term_init_command . ":\<C-U> TmuxNavigateLeft\<cr>"
+    tnoremap <expr> <silent> <C-j> IsFZF() ? "\<C-j>" : g:tmux_navigator_term_init_command . ":\<C-U> TmuxNavigateDown\<cr>"
+    tnoremap <expr> <silent> <C-k> IsFZF() ? "\<C-k>" : g:tmux_navigator_term_init_command . ":\<C-U> TmuxNavigateUp\<cr>"
+    tnoremap <expr> <silent> <C-l> IsFZF() ? "\<C-l>" : g:tmux_navigator_term_init_command . ":\<C-U> TmuxNavigateRight\<cr>"
   endif
 
   if !get(g:, 'tmux_navigator_disable_netrw_workaround', 0)


### PR DESCRIPTION
The navigation from terminals in insert mode only work in Vim, because the command used to initiate the navigate command (`<C-w>`) is Vim-only.

In Neovim there is `<C-\><C-N>` to exit insert mode in terminals. This is used in this PR for Neovim.

There is also a one-shot command in Neovim ([`<C-\><C-O>`](https://neovim.io/doc/user/terminal.html#t_CTRL-%5C_CTRL-O)), but it works differently than the one in Vim:

1. Exits insert mode
2. Executes navigation command
3. In the target window, it goes back to insert mode

IMO that's not what users expect. Also, when navigating back to the terminal, it's in normal mode. So I don't see an advantage here and think it's not suitable.