### PR TITLE
feat: add tmux_navigator_disable_when_zoomed option for tmux

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,15 @@ To disable navigation when zoomed, add the following to your ~/.vimrc:
 let g:tmux_navigator_disable_when_zoomed = 1
 ```
 
+If you are using TPM, you can also configure this behavior on the tmux side by
+adding the following to your ~/.tmux.conf:
+
+```tmux
+set -g @tmux_navigator_disable_when_zoomed "1"
+```
+
+This will prevent navigation to other tmux panes when the current pane is zoomed.
+
 ##### Preserve Zoom
 
 As noted above, navigating from a Vim pane to another tmux pane normally causes

--- a/vim-tmux-navigator.tmux
+++ b/vim-tmux-navigator.tmux
@@ -25,7 +25,7 @@ get_tmux_option() {
 declare vim_pattern='(\S+/)?g?\.?(view|l?n?vim?x?|fzf)(diff)?(-wrapped)?'
 
 bind_key_vim() {
-  local key tmux_cmd is_vim
+  local key tmux_cmd is_vim tmux_navigator_disable_when_zoomed
   key="$1"
   tmux_cmd="$2"
 
@@ -35,6 +35,11 @@ bind_key_vim() {
       | grep -iqE '^[^TXZ ]+ +"@vim_navigator_pattern"$'"
   is_vim="$(get_tmux_option "@vim_navigator_check" "${is_vim}")"
   is_vim="${is_vim//@vim_navigator_pattern/${vim_pattern}}"
+
+  tmux_navigator_disable_when_zoomed="$(get_tmux_option "@tmux_navigator_disable_when_zoomed" "0")"
+  if [ "$tmux_navigator_disable_when_zoomed" = "1" ]; then
+    tmux_cmd="if-shell -F '#{window_zoomed_flag}' '' '$tmux_cmd'"
+  fi
 
   # sending C-/ according to https://github.com/tmux/tmux/issues/1827
   tmux bind-key -n "$key" if-shell "$is_vim" "send-keys '$key'" "$tmux_cmd"


### PR DESCRIPTION
While an equivalent option exists for Vim, this PR introduces a new TPM configuration option, `@tmux_navigator_disable_when_zoomed`. This allows users to prevent accidental pane navigation when the current pane is zoomed, enforcing the behavior directly via .tmux.conf.