### PR TITLE
Fix is_vim check to work when docker is running

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,9 @@ Add the following to your `~/.tmux.conf` file:
 # Smart pane switching with awareness of Vim splits.
 # See: https://github.com/christoomey/vim-tmux-navigator
 vim_pattern='(\S+/)?g?\.?(view|l?n?vim?x?|fzf)(diff)?(-wrapped)?'
-is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
-    | grep -iqE '^[^TXZ ]+ +${vim_pattern}$'"
+sid="ps -o sid= -p '#{pane_pid}' | tr -d ' '"
+is_vim="ps -o stat= -o comm= -s \"\$($sid)\" \
+    | grep -iqE '^[^TXZ ]*\+ +${vim_pattern}$'"
 bind-key -n 'C-h' if-shell "$is_vim" 'send-keys C-h'  'select-pane -L'
 bind-key -n 'C-j' if-shell "$is_vim" 'send-keys C-j'  'select-pane -D'
 bind-key -n 'C-k' if-shell "$is_vim" 'send-keys C-k'  'select-pane -U'

--- a/vim-tmux-navigator.tmux
+++ b/vim-tmux-navigator.tmux
@@ -25,14 +25,15 @@ get_tmux_option() {
 declare vim_pattern='(\S+/)?g?\.?(view|l?n?vim?x?|fzf)(diff)?(-wrapped)?'
 
 bind_key_vim() {
-  local key tmux_cmd is_vim tmux_navigator_disable_when_zoomed
+  local key tmux_cmd sid is_vim tmux_navigator_disable_when_zoomed
   key="$1"
   tmux_cmd="$2"
 
   vim_pattern="$(get_tmux_option "@vim_navigator_pattern" "${vim_pattern}")"
 
-  is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
-      | grep -iqE '^[^TXZ ]+ +"@vim_navigator_pattern"$'"
+  sid="ps -o sid= -p '#{pane_pid}' | tr -d ' '"
+  is_vim="ps -o stat= -o comm= -s \"\$($sid)\" \
+      | grep -iqE '^[^TXZ ]*\+ +"@vim_navigator_pattern"$'"
   is_vim="$(get_tmux_option "@vim_navigator_check" "${is_vim}")"
   is_vim="${is_vim//@vim_navigator_pattern/${vim_pattern}}"
 


### PR DESCRIPTION
When docker is running, matching off of TTY can conflict with processes running in docker. This matches based on sessionID.

Full disclosure: the details of this fix came from ChatGPT. It was reviewed and fully tested by me.