### PR TITLE
Set vim mappings from g:navigator_key_X

### DIFF
--- a/plugin/tmux_navigator.vim
+++ b/plugin/tmux_navigator.vim
@@ -15,20 +15,20 @@ function! s:VimNavigate(direction)
 endfunction
 
 if !get(g:, 'tmux_navigator_no_mappings', 0)
-  nnoremap <silent> <c-h> :<C-U>TmuxNavigateLeft<cr>
-  nnoremap <silent> <c-j> :<C-U>TmuxNavigateDown<cr>
-  nnoremap <silent> <c-k> :<C-U>TmuxNavigateUp<cr>
-  nnoremap <silent> <c-l> :<C-U>TmuxNavigateRight<cr>
-  nnoremap <silent> <c-\> :<C-U>TmuxNavigatePrevious<cr>
+  execute "nnoremap <silent> " . g:navigator_key_h . " :<C-U>TmuxNavigateLeft<cr>"
+  execute "nnoremap <silent> " . g:navigator_key_j . " :<C-U>TmuxNavigateDown<cr>"
+  execute "nnoremap <silent> " . g:navigator_key_k . " :<C-U>TmuxNavigateUp<cr>"
+  execute "nnoremap <silent> " . g:navigator_key_l . " :<C-U>TmuxNavigateRight<cr>"
+  execute "nnoremap <silent> " . g:navigator_key_p . " :<C-U>TmuxNavigatePrevious<cr>"
 
   if !empty($TMUX)
     function! IsFZF()
       return &ft == 'fzf'
     endfunction
-    tnoremap <expr> <silent> <C-h> IsFZF() ? "\<C-h>" : "\<C-w>:\<C-U> TmuxNavigateLeft\<cr>"
-    tnoremap <expr> <silent> <C-j> IsFZF() ? "\<C-j>" : "\<C-w>:\<C-U> TmuxNavigateDown\<cr>"
-    tnoremap <expr> <silent> <C-k> IsFZF() ? "\<C-k>" : "\<C-w>:\<C-U> TmuxNavigateUp\<cr>"
-    tnoremap <expr> <silent> <C-l> IsFZF() ? "\<C-l>" : "\<C-w>:\<C-U> TmuxNavigateRight\<cr>"
+    execute "tnoremap <expr> <silent> " . g:navigator_key_h . " IsFZF() ? '" . g:navigator_key_h . "' : '\<C-w>:\<C-U> TmuxNavigateLeft\<cr>'"
+    execute "tnoremap <expr> <silent> " . g:navigator_key_j . " IsFZF() ? '" . g:navigator_key_j . "' : '\<C-w>:\<C-U> TmuxNavigateDown\<cr>'"
+    execute "tnoremap <expr> <silent> " . g:navigator_key_k . " IsFZF() ? '" . g:navigator_key_k . "' : '\<C-w>:\<C-U> TmuxNavigateUp\<cr>'"
+    execute "tnoremap <expr> <silent> " . g:navigator_key_l . " IsFZF() ? '" . g:navigator_key_l . "' : '\<C-w>:\<C-U> TmuxNavigateRight\<cr>'"
   endif
 
   if !get(g:, 'tmux_navigator_disable_netrw_workaround', 0)


### PR DESCRIPTION
This removes the need to set `g:navigator_key_X`, `g:tmux_navigator_no_mappings` and then do the individual mappings. With this change you just set `g:navigator_key_X` and everything is set up properly